### PR TITLE
feat: add i18n translation support for breeds

### DIFF
--- a/little-sheep/breed translation/create-breed-translation.bru
+++ b/little-sheep/breed translation/create-breed-translation.bru
@@ -1,0 +1,78 @@
+meta {
+  name: Create Breed Translation
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:8080/api/v1/breed-translations
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "breedId": "AdWNDqgV",
+    "language": "es",
+    "name": "Suffolk"
+  }
+}
+
+docs {
+  # Create Breed Translation
+
+  Creates a new translation for an existing breed in a specific language.
+
+  ## Authentication
+
+  **Required**: JWT cookie from login endpoint
+
+  ## Request Body
+
+  - `breedId` (string, required): Encoded ID of the breed to add translation for
+  - `language` (string, required): Language code (2 characters, e.g., "en", "es")
+  - `name` (string, required): Breed name in the specified language (minimum 1 character)
+
+  ## Response
+
+  **Success (201)**:
+  ```json
+  {
+    "status": "success",
+    "message": "Success",
+    "data": {
+      "id": "encoded_translation_id",
+      "breedId": "encoded_breed_id",
+      "language": "es",
+      "name": "Suffolk",
+      "createdAt": "2024-01-01T00:00:00.000Z",
+      "updatedAt": "2024-01-01T00:00:00.000Z"
+    },
+    "meta": {
+      "timestamp": "2024-01-01T00:00:00.000Z"
+    }
+  }
+  ```
+
+  **Error Responses**:
+  - `400`: Invalid request body (missing fields, invalid language code, or invalid breedId)
+  - `409`: Translation already exists for this breed and language combination
+
+  ## Notes
+
+  - Each breed can only have one translation per language
+  - Language code must be a valid 2-character code (e.g., "en", "es")
+  - The breedId must be a valid encoded breed ID
+  - All IDs in response are encoded using hashids for security
+  - Requires authentication to create translations
+
+  ## Internationalization Workflow
+
+  1. **Create Breed**: Use POST `/api/v1/breeds` with `name`, `language`, and `speciesId` to create a breed with its initial translation
+  2. **Add Translations**: Use this endpoint to add translations in other languages
+  3. **Query with Translations**: Use GET `/api/v1/breeds?speciesId=X&include=translations&language=en` to get breeds with filtered translations
+}

--- a/little-sheep/breed/create-breed.bru
+++ b/little-sheep/breed/create-breed.bru
@@ -16,27 +16,29 @@ headers {
 
 body:json {
   {
-    "speciesId": "NArJeWyE",
-    "name": "Holstein"
+    "speciesId": "AdWNDqgV",
+    "name": "Dorper",
+    "language": "en"
   }
 }
 
 docs {
   # Create Breed
-  
-  Creates a new breed for a specific animal species.
-  
+
+  Creates a new breed for a specific animal species with an initial translation.
+
   ## Authentication
-  
+
   **Required**: JWT cookie from login endpoint
-  
+
   ## Request Body
-  
-  - `name` (string, required): Name of the breed
+
   - `speciesId` (string, required): Encoded ID of the species this breed belongs to
-  
+  - `name` (string, required): Name of the breed in the specified language
+  - `language` (string, required): Language code (2 characters, e.g., "en", "es")
+
   ## Response
-  
+
   **Success (201)**:
   ```json
   {
@@ -44,24 +46,34 @@ docs {
     "message": "Success",
     "data": {
       "id": "encoded_breed_id",
-      "speciesId": "encoded_species_id", 
-      "name": "Holstein",
+      "speciesId": "encoded_species_id",
       "createdAt": "2024-01-01T00:00:00.000Z",
-      "updatedAt": "2024-01-01T00:00:00.000Z"
+      "updatedAt": "2024-01-01T00:00:00.000Z",
+      "translations": [
+        {
+          "id": "encoded_translation_id",
+          "breedId": "encoded_breed_id",
+          "language": "en",
+          "name": "Dorper",
+          "createdAt": "2024-01-01T00:00:00.000Z",
+          "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+      ]
     },
     "meta": {
       "timestamp": "2024-01-01T00:00:00.000Z"
     }
   }
   ```
-  
+
   **Error Responses**:
-  - `400`: Invalid request body (missing name or speciesId)
-  - `409`: Breed name already exists for this species
-  
+  - `400`: Invalid request body (missing name, speciesId, or language)
+  - `409`: Breed translation already exists for this language
+
   ## Notes
-  
-  - Breed names must be unique within each species
+
+  - Creates both the breed record and its initial translation in one call
+  - Use the breed-translations endpoint to add translations in other languages
   - The speciesId must be a valid encoded species ID
   - All IDs in response are encoded using hashids for security
   - Requires authentication to create breeds

--- a/little-sheep/breed/list-breeds.bru
+++ b/little-sheep/breed/list-breeds.bru
@@ -1,36 +1,37 @@
 meta {
   name: List Breeds
   type: http
-  seq: 1
+  seq: 2
 }
 
 get {
-  url: http://localhost:8080/api/v1/breeds?speciesId=AdWNDqgV&order=name:asc
+  url: http://localhost:8080/api/v1/breeds?speciesId=AdWNDqgV&include=translations&language=en
   body: none
   auth: none
 }
 
 params:query {
   speciesId: AdWNDqgV
-  order: name:asc
+  include: translations
+  language: en
 }
 
 docs {
   # List Breeds
-  
-  Retrieves all breeds filtered by species ID with optional sorting.
-  
+
+  Retrieves all breeds filtered by species ID with optional translation support.
+
   ## Query Parameters
-  
+
   - `speciesId` (string, required): Encoded species ID to filter breeds
+  - `include` (string, optional): Comma-separated list of relations to include (e.g., `translations`)
+  - `language` (string, optional): Language code to filter translations (e.g., "en", "es"). Only applies when `include=translations`
   - `order` (string, optional): Sorting order for results
-    - Available fields: `name`, `id`, `createdAt`
-    - Format: `field:direction` (e.g., `name:asc`, `createdAt:desc`)
-    - Multiple sorts: `name:asc,createdAt:desc`
-    - Default: `name:asc`
-  
+    - Available fields: `id`, `createdAt`
+    - Format: `field:direction` (e.g., `id:asc`, `createdAt:desc`)
+
   ## Response
-  
+
   **Success (200)**:
   ```json
   {
@@ -39,17 +40,19 @@ docs {
     "data": [
       {
         "id": "encoded_breed_id",
-        "name": "Holstein",
         "speciesId": "encoded_species_id",
         "createdAt": "2024-01-01T00:00:00.000Z",
-        "updatedAt": "2024-01-01T00:00:00.000Z"
-      },
-      {
-        "id": "encoded_breed_id_2",
-        "name": "Jersey",
-        "speciesId": "encoded_species_id",
-        "createdAt": "2024-01-01T00:00:00.000Z",
-        "updatedAt": "2024-01-01T00:00:00.000Z"
+        "updatedAt": "2024-01-01T00:00:00.000Z",
+        "translations": [
+          {
+            "id": "encoded_translation_id",
+            "breedId": "encoded_breed_id",
+            "language": "en",
+            "name": "Suffolk",
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-01T00:00:00.000Z"
+          }
+        ]
       }
     ],
     "meta": {
@@ -57,16 +60,15 @@ docs {
     }
   }
   ```
-  
+
   **Error Responses**:
-  - `400`: Invalid speciesId parameter
-  
+  - `400`: Invalid speciesId or query parameters
+
   ## Notes
-  
-  - Default ordering is alphabetically by name (ascending)
-  - Species ID must be a valid encoded ID
+
+  - Without `include=translations`, breeds are returned without translation data
+  - When `language` is provided with `include=translations`, only translations for that language are returned
+  - Without `language`, all translations are returned
   - Returns empty array if no breeds found for the species
   - All IDs are encoded using hashids for security
-  - Invalid order parameters will return a 400 error
-  - Sorting is case-sensitive for string fields
 }

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -9,6 +9,10 @@ import {
 	SpeciesTranslationModel,
 } from '../resources/species-translation/species-translation.model';
 import { BreedModel, initBreedModel } from '../resources/breed/breed.model';
+import {
+	BreedTranslationModel,
+	initBreedTranslationModel,
+} from '../resources/breed-translation/breed-translation.model';
 import { AnimalModel, initAnimalModel } from '../resources/animal/animal.model';
 import {
 	AnimalMeasurementModel,
@@ -26,6 +30,7 @@ export interface Database {
 		Species: typeof SpeciesModel;
 		SpeciesTranslation: typeof SpeciesTranslationModel;
 		Breed: typeof BreedModel;
+		BreedTranslation: typeof BreedTranslationModel;
 		Animal: typeof AnimalModel;
 		AnimalMeasurement: typeof AnimalMeasurementModel;
 		Expense: typeof ExpenseModel;
@@ -65,6 +70,7 @@ export const initDatabase = async (): Promise<Database> => {
 	const SpeciesTranslation = initSpeciesTranslationModel(sequelize);
 	const Species = initSpeciesModel(sequelize);
 	const Breed = initBreedModel(sequelize);
+	const BreedTranslation = initBreedTranslationModel(sequelize);
 	const Animal = initAnimalModel(sequelize);
 	const AnimalMeasurement = initAnimalMeasurementModel(sequelize);
 	const Expense = initExpenseModel(sequelize);
@@ -83,6 +89,10 @@ export const initDatabase = async (): Promise<Database> => {
 	// Breed & Species
 	Species.hasMany(Breed, { foreignKey: 'speciesId', as: 'breeds' });
 	Breed.belongsTo(Species, { foreignKey: 'speciesId', as: 'species' });
+
+	// Breed & BreedTranslation
+	Breed.hasMany(BreedTranslation, { foreignKey: 'breedId', as: 'translations' });
+	BreedTranslation.belongsTo(Breed, { foreignKey: 'breedId', as: 'breed' });
 
 	// Animal associations
 	Animal.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
@@ -115,6 +125,7 @@ export const initDatabase = async (): Promise<Database> => {
 			Species,
 			SpeciesTranslation,
 			Breed,
+			BreedTranslation,
 			Animal,
 			AnimalMeasurement,
 			Expense,

--- a/src/migrations/20260313120000-breed-translation-migration.js
+++ b/src/migrations/20260313120000-breed-translation-migration.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Migration to create the breed_translation table.
+ * Mirrors the species_translation pattern for i18n support.
+ */
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('breed_translation', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			breed_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'breeds',
+					key: 'id',
+				},
+				onDelete: 'CASCADE',
+			},
+			language_code: {
+				type: Sequelize.STRING(5),
+				allowNull: false,
+			},
+			name: {
+				type: Sequelize.STRING,
+				allowNull: false,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+			},
+		});
+
+		// Add unique constraint for (breed_id, language_code)
+		await queryInterface.addConstraint('breed_translation', {
+			fields: ['breed_id', 'language_code'],
+			type: 'unique',
+			name: 'unique_breed_language',
+		});
+
+		// Note: no (name, language_code) constraint — different species can share breed names (e.g. "Other")
+	},
+
+	down: async (queryInterface, _Sequelize) => {
+		await queryInterface.dropTable('breed_translation');
+	},
+};

--- a/src/migrations/20260313120001-remove-breed-name-migration.js
+++ b/src/migrations/20260313120001-remove-breed-name-migration.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Migration to remove the name column from breeds table.
+ * Copies existing breed names into breed_translation (as 'en') before dropping the column.
+ */
+
+module.exports = {
+	up: async (queryInterface, _Sequelize) => {
+		// Copy existing breed names into breed_translation as English translations
+		await queryInterface.sequelize.query(`
+			INSERT INTO breed_translation (breed_id, language_code, name, created_at, updated_at)
+			SELECT id, 'en', name, created_at, updated_at
+			FROM breeds
+			WHERE name IS NOT NULL AND name != ''
+		`);
+
+		// Remove the unique constraint on (species_id, name)
+		await queryInterface.removeIndex('breeds', ['species_id', 'name']);
+
+		// Remove the name column
+		await queryInterface.removeColumn('breeds', 'name');
+	},
+
+	down: async (queryInterface, Sequelize) => {
+		// Re-add the name column
+		await queryInterface.addColumn('breeds', 'name', {
+			type: Sequelize.STRING,
+			allowNull: false,
+			defaultValue: '',
+		});
+
+		// Restore names from English translations
+		await queryInterface.sequelize.query(`
+			UPDATE breeds
+			SET name = bt.name
+			FROM breed_translation bt
+			WHERE bt.breed_id = breeds.id AND bt.language_code = 'en'
+		`);
+
+		// Re-add the unique constraint
+		await queryInterface.addIndex('breeds', ['species_id', 'name'], {
+			unique: true,
+			name: 'breeds_species_id_name',
+		});
+
+		// Remove the migrated translations
+		await queryInterface.sequelize.query(`
+			DELETE FROM breed_translation
+		`);
+	},
+};

--- a/src/plugins/services.plugin.ts
+++ b/src/plugins/services.plugin.ts
@@ -6,6 +6,7 @@ import { AnimalService } from '../resources/animal/animal.service';
 import { AnimalMeasurementService } from '../resources/animal-measurement/animal-measurement.service';
 import { AuthService } from '../resources/auth/auth.service';
 import { BreedService } from '../resources/breed/breed.service';
+import { BreedTranslationService } from '../resources/breed-translation/breed-translation.service';
 import { ExpenseService } from '../resources/expense/expense.service';
 import { FarmService } from '../resources/farm/farm.service';
 import { FarmMemberService } from '../resources/farm-member/farm-member.service';
@@ -22,6 +23,7 @@ const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	fastify.decorate('animalMeasurementService', new AnimalMeasurementService(fastify.db));
 	fastify.decorate('authService', new AuthService(fastify.db));
 	fastify.decorate('breedService', new BreedService(fastify.db));
+	fastify.decorate('breedTranslationService', new BreedTranslationService(fastify.db));
 	fastify.decorate('expenseService', new ExpenseService(fastify.db));
 	fastify.decorate('farmService', new FarmService(fastify.db));
 	fastify.decorate('farmMemberService', new FarmMemberService(fastify.db));

--- a/src/resources/animal/animal.schema.ts
+++ b/src/resources/animal/animal.schema.ts
@@ -7,6 +7,7 @@ import { AnimalModel } from './animal.model';
 import { SpeciesModel } from '../species/species.model';
 import { SpeciesTranslationModel } from '../species-translation/species-translation.model';
 import { BreedModel } from '../breed/breed.model';
+import { BreedTranslationModel } from '../breed-translation/breed-translation.model';
 import { AnimalMeasurementModel } from '../animal-measurement/animal-measurement.model';
 import { UserLanguage } from '../user/user.schema';
 
@@ -39,7 +40,9 @@ export type AnimalWithPossibleIncludes = AnimalModel & {
 	species?: SpeciesModel & {
 		translations?: SpeciesTranslationModel[];
 	};
-	breed?: BreedModel;
+	breed?: BreedModel & {
+		translations?: BreedTranslationModel[];
+	};
 	father?: AnimalModel;
 	mother?: AnimalModel;
 	measurements?: AnimalMeasurementModel[];

--- a/src/resources/animal/animal.serializer.ts
+++ b/src/resources/animal/animal.serializer.ts
@@ -48,10 +48,19 @@ export class AnimalSerializer {
 		if (animal.breed) {
 			result.breed = {
 				id: encodeId(animal.breed.id),
-				name: animal.breed.name,
 				createdAt: animal.breed.createdAt,
 				updatedAt: animal.breed.updatedAt,
 				speciesId: encodeId(animal.breed.speciesId),
+				...(animal.breed.translations && {
+					translations: animal.breed.translations.map(t => ({
+						id: encodeId(t.id),
+						language: t.language,
+						name: t.name,
+						createdAt: t.createdAt,
+						updatedAt: t.updatedAt,
+						breedId: encodeId(t.breedId),
+					})),
+				}),
 			};
 		}
 

--- a/src/resources/animal/animal.service.ts
+++ b/src/resources/animal/animal.service.ts
@@ -25,7 +25,14 @@ export class AnimalService extends BaseService {
 		breed: {
 			model: 'Breed' as const,
 			as: 'breed',
-			attributes: ['id', 'name', 'createdAt', 'updatedAt', 'speciesId'],
+			attributes: ['id', 'createdAt', 'updatedAt', 'speciesId'],
+			nested: {
+				translations: {
+					model: 'BreedTranslation' as const,
+					as: 'translations',
+					attributes: ['id', 'breedId', 'language', 'name', 'createdAt', 'updatedAt'],
+				},
+			},
 		},
 		father: {
 			model: 'Animal' as const,
@@ -62,8 +69,8 @@ export class AnimalService extends BaseService {
 		let includes = this.parseIncludes(includeParam, AnimalService.ALLOWED_INCLUDES);
 		const filterWhere = this.parseFilters(filters, AnimalService.ALLOWED_FILTERS);
 
-		// Filter species translations by language if species and translations are included
-		if (includeParam?.includes('species.translations')) {
+		// Filter translations by language if included
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
 			includes = this.filterTranslationsByLanguage(includes, language);
 		}
 
@@ -125,8 +132,8 @@ export class AnimalService extends BaseService {
 
 		let includes = this.parseIncludes(includeParam, AnimalService.ALLOWED_INCLUDES);
 
-		// Filter species translations by language if species and translations are included
-		if (includeParam?.includes('species.translations')) {
+		// Filter translations by language if included
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
 			includes = this.filterTranslationsByLanguage(includes, language);
 		}
 

--- a/src/resources/breed-translation/breed-translation.model.ts
+++ b/src/resources/breed-translation/breed-translation.model.ts
@@ -1,0 +1,60 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { BreedTranslation } from './breed-translation.schema';
+import { UserLanguage } from '../user/user.schema';
+
+type BreedTranslationCreationAttributes = Pick<BreedTranslation, 'breedId' | 'language' | 'name'>;
+
+export class BreedTranslationModel extends Model<BreedTranslation, BreedTranslationCreationAttributes> {
+	declare id: number;
+	declare breedId: number;
+	declare language: UserLanguage;
+	declare name: string;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initBreedTranslationModel = (sequelize: Sequelize) => BreedTranslationModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	breedId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'breed_id',
+		references: {
+			model: 'breeds',
+			key: 'id',
+		},
+		onDelete: 'CASCADE',
+	},
+	language: {
+		type: DataTypes.ENUM(...Object.values(UserLanguage)),
+		allowNull: false,
+		field: 'language_code',
+	},
+	name: {
+		type: DataTypes.STRING,
+		allowNull: false,
+		field: 'name',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'breed_translation',
+	modelName: 'BreedTranslation',
+	timestamps: true,
+});

--- a/src/resources/breed-translation/breed-translation.routes.ts
+++ b/src/resources/breed-translation/breed-translation.routes.ts
@@ -1,0 +1,26 @@
+import { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import { createBreedTranslationSchema, CreateBreedTranslation } from './breed-translation.schema';
+import { BreedTranslationSerializer } from './breed-translation.serializer';
+import { decodeId } from '../../utils/id-hash-util';
+
+const breedTranslationRoutes: FastifyPluginAsync = async (fastify) => {
+	fastify.post('/', {
+		schema: createBreedTranslationSchema,
+	}, async (request: FastifyRequest<{ Body: CreateBreedTranslation }>, reply) => {
+		try {
+			const { breedId, language, name } = request.body;
+			const decodedBreedId = decodeId(breedId);
+			const breedTranslation = await fastify.breedTranslationService.createBreedTranslation({
+				breedId: decodedBreedId!,
+				language,
+				name,
+			});
+			const serializedBreedTranslation = BreedTranslationSerializer.serialize(breedTranslation);
+			reply.success(serializedBreedTranslation);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default breedTranslationRoutes;

--- a/src/resources/breed-translation/breed-translation.schema.ts
+++ b/src/resources/breed-translation/breed-translation.schema.ts
@@ -1,0 +1,42 @@
+import { Static, Type } from '@sinclair/typebox';
+import { createPostEndpointSchema } from '../../utils/schema-builder';
+
+const BreedTranslationSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	breedId: Type.Integer({ minimum: 1 }),
+	language: Type.String({ minLength: 2, maxLength: 2 }),
+	name: Type.String({ minLength: 1 }),
+	createdAt: Type.String({ format: 'date-time' }),
+	updatedAt: Type.String({ format: 'date-time' }),
+}, {
+	$id: 'breedTranslation',
+	additionalProperties: false,
+});
+
+export const BreedTranslationCreateSchema = Type.Object({
+	breedId: Type.String(),
+	language: Type.String({ minLength: 2, maxLength: 2 }),
+	name: Type.String({ minLength: 1 }),
+}, {
+	$id: 'breedTranslationCreate',
+	additionalProperties: false,
+});
+
+export const BreedTranslationResponseSchema = Type.Object({
+	...BreedTranslationSchema.properties,
+	id: Type.String(),
+	breedId: Type.String(),
+}, {
+	$id: 'breedTranslationResponse',
+	additionalProperties: false,
+});
+
+export type BreedTranslation = Static<typeof BreedTranslationSchema>;
+export type CreateBreedTranslation = Static<typeof BreedTranslationCreateSchema>;
+export type BreedTranslationResponse = Static<typeof BreedTranslationResponseSchema>;
+
+export const createBreedTranslationSchema = createPostEndpointSchema({
+	body: BreedTranslationCreateSchema,
+	dataSchema: BreedTranslationResponseSchema,
+	errorCodes: [400, 409],
+});

--- a/src/resources/breed-translation/breed-translation.serializer.ts
+++ b/src/resources/breed-translation/breed-translation.serializer.ts
@@ -1,0 +1,20 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { BreedTranslationModel } from './breed-translation.model';
+import { BreedTranslationResponse } from './breed-translation.schema';
+
+export class BreedTranslationSerializer {
+	static serialize(breedTranslation: BreedTranslationModel): BreedTranslationResponse {
+		return {
+			id: encodeId(breedTranslation.id),
+			breedId: encodeId(breedTranslation.breedId),
+			language: breedTranslation.language,
+			name: breedTranslation.name,
+			createdAt: breedTranslation.createdAt,
+			updatedAt: breedTranslation.updatedAt,
+		};
+	}
+
+	static serializeMany(breedTranslations: BreedTranslationModel[]): BreedTranslationResponse[] {
+		return breedTranslations.map(breedTranslation => this.serialize(breedTranslation));
+	}
+}

--- a/src/resources/breed-translation/breed-translation.service.ts
+++ b/src/resources/breed-translation/breed-translation.service.ts
@@ -1,0 +1,17 @@
+import { BaseService } from '../../services/base.service';
+import { BreedTranslationModel } from './breed-translation.model';
+
+interface CreateBreedTranslationInput {
+	breedId: number;
+	language: string;
+	name: string;
+}
+
+export class BreedTranslationService extends BaseService {
+
+	async createBreedTranslation(data: CreateBreedTranslationInput): Promise<BreedTranslationModel> {
+		const breedTranslation = await this.db.models.BreedTranslation.create(data);
+		return breedTranslation;
+	}
+
+}

--- a/src/resources/breed-translation/index.ts
+++ b/src/resources/breed-translation/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import breedTranslationRoutes from './breed-translation.routes';
+
+const breedTranslationPlugin: FastifyPluginAsync = async (fastify) => {
+	fastify.register(breedTranslationRoutes, { prefix: '/breed-translations' });
+};
+
+export default breedTranslationPlugin;

--- a/src/resources/breed/breed.model.ts
+++ b/src/resources/breed/breed.model.ts
@@ -6,7 +6,6 @@ type BreedCreationAttributes = Omit<Breed, 'id' | 'createdAt' | 'updatedAt'>;
 export class BreedModel extends Model<Breed, BreedCreationAttributes> {
 	declare id: number;
 	declare speciesId: number;
-	declare name: string;
 	declare createdAt: string;
 	declare updatedAt: string;
 }
@@ -28,11 +27,6 @@ export const initBreedModel = (sequelize: Sequelize) => BreedModel.init({
 		},
 		onDelete: 'CASCADE',
 	},
-	name: {
-		type: DataTypes.STRING,
-		allowNull: false,
-		field: 'name',
-	},
 	createdAt: {
 		type: DataTypes.DATE,
 		allowNull: false,
@@ -50,10 +44,4 @@ export const initBreedModel = (sequelize: Sequelize) => BreedModel.init({
 	tableName: 'breeds',
 	modelName: 'Breed',
 	timestamps: true,
-	indexes: [
-		{
-			unique: true,
-			fields: ['species_id', 'name'],
-		},
-	],
 });

--- a/src/resources/breed/breed.routes.ts
+++ b/src/resources/breed/breed.routes.ts
@@ -2,14 +2,20 @@ import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
 import { BreedCreate, BreedQuery, createBreedSchema, getBreedsSchema } from './breed.schema';
 import { decodeId } from '../../utils/id-hash-util';
 import { BreedSerializer } from './breed.serializer';
+import { UserLanguage } from '../user/user.schema';
 
 const breedRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
 	fastify.get('/', { schema: getBreedsSchema }, async (request: FastifyRequest<{Querystring: BreedQuery}>, reply) => {
 		try {
-			const { speciesId, order } = request.query;
+			const { speciesId, order, include, language } = request.query;
 			const decodedSpeciesId = decodeId(speciesId);
-			const breeds = await fastify.breedService.getBreedsBySpecies(decodedSpeciesId!, order);
+			const breeds = await fastify.breedService.getBreedsBySpecies(
+				decodedSpeciesId!,
+				order,
+				include,
+				language as UserLanguage | undefined,
+			);
 			const serializedBreeds = breeds.map(breed => BreedSerializer.serialize(breed));
 			reply.success(serializedBreeds);
 		} catch (error) {
@@ -19,10 +25,14 @@ const breedRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 
 	fastify.post('/', { schema: createBreedSchema }, async (request: FastifyRequest<{Body: BreedCreate}>, reply) => {
 		try {
-			const { name, speciesId } = request.body;
+			const { name, speciesId, language } = request.body;
 			const decodedId = decodeId(speciesId);
-			const breed = await fastify.breedService.createBreed({ name, speciesId: decodedId! });
-			const serializedBreed = BreedSerializer.serialize(breed);
+			const { breed, translation } = await fastify.breedService.createBreed({
+				name,
+				language,
+				speciesId: decodedId!,
+			});
+			const serializedBreed = BreedSerializer.serialize(breed, [translation]);
 			reply.success(serializedBreed);
 		} catch (error) {
 			fastify.handleDbError(error, reply);

--- a/src/resources/breed/breed.schema.ts
+++ b/src/resources/breed/breed.schema.ts
@@ -1,10 +1,11 @@
 import { Type, Static } from '@sinclair/typebox';
-import { createPostEndpointSchema, createUpdateEndpointSchema, createGetEndpointSchema } from '../../utils/schema-builder';
+import { createPostEndpointSchema, createGetEndpointSchema } from '../../utils/schema-builder';
+import { BreedTranslationResponseSchema } from '../breed-translation/breed-translation.schema';
+import { UserLanguage } from '../user/user.schema';
 
 const BreedSchema = Type.Object({
 	id: Type.Integer({ minimum: 1 }),
 	speciesId: Type.Integer({ minimum: 1 }),
-	name: Type.String(),
 	createdAt: Type.Optional(Type.String()),
 	updatedAt: Type.Optional(Type.String()),
 }, {
@@ -13,17 +14,11 @@ const BreedSchema = Type.Object({
 });
 
 const BreedCreateSchema = Type.Object({
-	name: Type.String(),
+	name: Type.String({ minLength: 1 }),
+	language: Type.String({ minLength: 2, maxLength: 2 }),
 	speciesId: Type.String(),
 }, {
 	$id: 'breedCreate',
-	additionalProperties: false,
-});
-
-const BreedUpdateSchema = Type.Object({
-	name: Type.String(),
-}, {
-	$id: 'breedUpdate',
 	additionalProperties: false,
 });
 
@@ -31,7 +26,7 @@ export const BreedResponseSchema = Type.Object({
 	...BreedSchema.properties,
 	id: Type.String(),
 	speciesId: Type.String(),
-
+	translations: Type.Optional(Type.Array(BreedTranslationResponseSchema)),
 }, {
 	$id: 'breedResponse',
 	additionalProperties: false,
@@ -44,6 +39,8 @@ const BreedParamsSchema = Type.Object({
 const BreedQuerySchema = Type.Object({
 	speciesId: Type.String(),
 	order: Type.Optional(Type.String()),
+	include: Type.Optional(Type.String()),
+	language: Type.Optional(Type.Enum(UserLanguage)),
 }, {
 	$id: 'breedQuery',
 	additionalProperties: false,
@@ -52,7 +49,6 @@ const BreedQuerySchema = Type.Object({
 export type Breed = Static<typeof BreedSchema>;
 export type BreedCreate = Static<typeof BreedCreateSchema>;
 export type BreedResponse = Static<typeof BreedResponseSchema>;
-export type BreedUpdate = Static<typeof BreedUpdateSchema>;
 export type BreedParams = Static<typeof BreedParamsSchema>;
 export type BreedQuery = Static<typeof BreedQuerySchema>;
 
@@ -60,12 +56,6 @@ export const createBreedSchema = createPostEndpointSchema({
 	body: BreedCreateSchema,
 	dataSchema: BreedResponseSchema,
 	errorCodes: [400, 409],
-});
-
-export const updateBreedSchema = createUpdateEndpointSchema({
-	body: BreedUpdateSchema,
-	dataSchema: BreedResponseSchema,
-	params: BreedParamsSchema,
 });
 
 export const getBreedsSchema = createGetEndpointSchema({

--- a/src/resources/breed/breed.serializer.ts
+++ b/src/resources/breed/breed.serializer.ts
@@ -1,15 +1,31 @@
 import { encodeId } from '../../utils/id-hash-util';
 import { BreedModel } from './breed.model';
 import { BreedResponse } from './breed.schema';
+import { BreedTranslationModel } from '../breed-translation/breed-translation.model';
+import { BreedTranslationSerializer } from '../breed-translation/breed-translation.serializer';
+
+type BreedWithTranslations = BreedModel & {
+	translations?: BreedTranslationModel[];
+};
 
 export class BreedSerializer {
-	static serialize(breed: BreedModel): BreedResponse {
-		return {
+	static serialize(breed: BreedWithTranslations, translations?: BreedTranslationModel[]): BreedResponse {
+		const result: BreedResponse = {
 			id: encodeId(breed.id),
-			name: breed.name,
 			speciesId: encodeId(breed.speciesId),
 			createdAt: breed.createdAt,
 			updatedAt: breed.updatedAt,
 		};
+
+		const translationsData = translations ?? breed.translations;
+		if (translationsData && translationsData.length > 0) {
+			result.translations = BreedTranslationSerializer.serializeMany(translationsData);
+		}
+
+		return result;
+	}
+
+	static serializeMany(breeds: BreedWithTranslations[]): BreedResponse[] {
+		return breeds.map(breed => this.serialize(breed));
 	}
 }

--- a/src/resources/breed/breed.service.ts
+++ b/src/resources/breed/breed.service.ts
@@ -1,15 +1,14 @@
-import { BreedUpdate } from './breed.schema';
 import { BaseService } from '../../services/base.service';
 import { BreedModel } from './breed.model';
+import { BreedTranslationModel } from '../breed-translation/breed-translation.model';
+import { IncludeParser, TypedIncludeConfig } from '../../utils/include-parser';
 import { OrderParser, TypedOrderConfig } from '../../utils/order-parser';
 import { FindOptions } from 'sequelize';
+import { UserLanguage } from '../user/user.schema';
 
 export class BreedService extends BaseService {
 
 	private static readonly ALLOWED_ORDERS = OrderParser.createConfig({
-		name: {
-			attribute: 'name',
-		},
 		id: {
 			attribute: 'id',
 		},
@@ -18,36 +17,38 @@ export class BreedService extends BaseService {
 		},
 	} satisfies TypedOrderConfig);
 
-	async createBreed({ name, speciesId }:{ name: string, speciesId: number }): Promise<BreedModel> {
-		return await this.db.models.Breed.create({ name, speciesId });
+	private static readonly ALLOWED_INCLUDES = IncludeParser.createConfig({
+		translations: {
+			model: 'BreedTranslation' as const,
+			as: 'translations',
+			attributes: ['id', 'breedId', 'language', 'name', 'createdAt', 'updatedAt'],
+		},
+	} satisfies TypedIncludeConfig);
+
+	async createBreed({ name, language, speciesId }: { name: string; language: string; speciesId: number }): Promise<{ breed: BreedModel; translation: BreedTranslationModel }> {
+		const breed = await this.db.models.Breed.create({ speciesId });
+		const translation = await this.db.models.BreedTranslation.create({
+			breedId: breed.id,
+			language,
+			name,
+		});
+		return { breed, translation };
 	}
 
-	async getBreedsBySpecies(speciesId: number, order?: string): Promise<BreedModel[]> {
+	async getBreedsBySpecies(speciesId: number, order?: string, includeParam?: string, language?: UserLanguage): Promise<BreedModel[]> {
 		const findOptions: FindOptions = {
 			where: { speciesId },
 		};
 
+		let includes = this.parseIncludes(includeParam, BreedService.ALLOWED_INCLUDES);
+
+		if (includeParam?.includes('translations') && language) {
+			includes = this.filterTranslationsByLanguage(includes, language);
+		}
+
+		findOptions.include = includes;
 		findOptions.order = this.parseOrder(order, BreedService.ALLOWED_ORDERS);
 
 		return await this.db.models.Breed.findAll(findOptions);
-	}
-
-	async updateBreed(id: number, data: BreedUpdate): Promise<BreedModel> {
-
-		const [affectedCount] = await this.db.models.Breed.update(data, {
-			where: { id },
-		});
-
-		if (affectedCount === 0) {
-			throw new Error('Breed not found');
-		}
-
-		const updatedBreed = await this.db.models.Breed.findByPk(id);
-		if (!updatedBreed) {
-			throw new Error('Breed not found after update');
-		}
-
-		return updatedBreed;
-
 	}
 }

--- a/src/seeders/2-breed-demo-data-seeder.js
+++ b/src/seeders/2-breed-demo-data-seeder.js
@@ -3,34 +3,64 @@
 module.exports = {
 	up: async (queryInterface, Sequelize) => {
 		const now = new Date();
+
+		// Insert breeds (base table, no name)
 		const breeds = [
 			// sheep (species_id: 1)
-			{ species_id: 1, name: "Suffolk", created_at: now, updated_at: now },
-			{ species_id: 1, name: "Merino", created_at: now, updated_at: now },
-			{ species_id: 1, name: "Other", created_at: now, updated_at: now },
+			{ species_id: 1, created_at: now, updated_at: now },
+			{ species_id: 1, created_at: now, updated_at: now },
+			{ species_id: 1, created_at: now, updated_at: now },
 			// cattle (species_id: 2)
-			{ species_id: 2, name: "Holstein", created_at: now, updated_at: now },
-			{ species_id: 2, name: "Angus", created_at: now, updated_at: now },
-			{ species_id: 2, name: "Other", created_at: now, updated_at: now },
+			{ species_id: 2, created_at: now, updated_at: now },
+			{ species_id: 2, created_at: now, updated_at: now },
+			{ species_id: 2, created_at: now, updated_at: now },
 			// goat (species_id: 3)
-			{ species_id: 3, name: "Boer", created_at: now, updated_at: now },
-			{ species_id: 3, name: "Saanen", created_at: now, updated_at: now },
-			{ species_id: 3, name: "Other", created_at: now, updated_at: now },
+			{ species_id: 3, created_at: now, updated_at: now },
+			{ species_id: 3, created_at: now, updated_at: now },
+			{ species_id: 3, created_at: now, updated_at: now },
 			// pig (species_id: 4)
-			{ species_id: 4, name: "Yorkshire", created_at: now, updated_at: now },
-			{ species_id: 4, name: "Duroc", created_at: now, updated_at: now },
-			{ species_id: 4, name: "Other", created_at: now, updated_at: now },
+			{ species_id: 4, created_at: now, updated_at: now },
+			{ species_id: 4, created_at: now, updated_at: now },
+			{ species_id: 4, created_at: now, updated_at: now },
 		];
 		await queryInterface.bulkInsert("breeds", breeds, {});
+
+		// Insert breed translations (en + es)
+		const breedTranslations = [
+			// sheep breeds (breed_id: 1-3)
+			{ breed_id: 1, language_code: "en", name: "Suffolk", created_at: now, updated_at: now },
+			{ breed_id: 1, language_code: "es", name: "Suffolk", created_at: now, updated_at: now },
+			{ breed_id: 2, language_code: "en", name: "Merino", created_at: now, updated_at: now },
+			{ breed_id: 2, language_code: "es", name: "Merino", created_at: now, updated_at: now },
+			{ breed_id: 3, language_code: "en", name: "Other", created_at: now, updated_at: now },
+			{ breed_id: 3, language_code: "es", name: "Otro", created_at: now, updated_at: now },
+			// cattle breeds (breed_id: 4-6)
+			{ breed_id: 4, language_code: "en", name: "Holstein", created_at: now, updated_at: now },
+			{ breed_id: 4, language_code: "es", name: "Holstein", created_at: now, updated_at: now },
+			{ breed_id: 5, language_code: "en", name: "Angus", created_at: now, updated_at: now },
+			{ breed_id: 5, language_code: "es", name: "Angus", created_at: now, updated_at: now },
+			{ breed_id: 6, language_code: "en", name: "Other", created_at: now, updated_at: now },
+			{ breed_id: 6, language_code: "es", name: "Otro", created_at: now, updated_at: now },
+			// goat breeds (breed_id: 7-9)
+			{ breed_id: 7, language_code: "en", name: "Boer", created_at: now, updated_at: now },
+			{ breed_id: 7, language_code: "es", name: "Boer", created_at: now, updated_at: now },
+			{ breed_id: 8, language_code: "en", name: "Saanen", created_at: now, updated_at: now },
+			{ breed_id: 8, language_code: "es", name: "Saanen", created_at: now, updated_at: now },
+			{ breed_id: 9, language_code: "en", name: "Other", created_at: now, updated_at: now },
+			{ breed_id: 9, language_code: "es", name: "Otro", created_at: now, updated_at: now },
+			// pig breeds (breed_id: 10-12)
+			{ breed_id: 10, language_code: "en", name: "Yorkshire", created_at: now, updated_at: now },
+			{ breed_id: 10, language_code: "es", name: "Yorkshire", created_at: now, updated_at: now },
+			{ breed_id: 11, language_code: "en", name: "Duroc", created_at: now, updated_at: now },
+			{ breed_id: 11, language_code: "es", name: "Duroc", created_at: now, updated_at: now },
+			{ breed_id: 12, language_code: "en", name: "Other", created_at: now, updated_at: now },
+			{ breed_id: 12, language_code: "es", name: "Otro", created_at: now, updated_at: now },
+		];
+		await queryInterface.bulkInsert("breed_translation", breedTranslations, {});
 	},
 
 	down: async (queryInterface, Sequelize) => {
-		await queryInterface.bulkDelete(
-			"breeds",
-			{
-				name: ["Suffolk", "Merino", "Holstein", "Angus", "Boer", "Saanen", "Yorkshire", "Duroc"],
-			},
-			{}
-		);
+		await queryInterface.bulkDelete("breed_translation", null, {});
+		await queryInterface.bulkDelete("breeds", null, {});
 	},
 };

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -5,6 +5,7 @@ import { AnimalService } from '../src/resources/animal/animal.service';
 import { AnimalMeasurementService } from '../src/resources/animal-measurement/animal-measurement.service';
 import { AuthService } from '../src/resources/auth/auth.service';
 import { BreedService } from '../src/resources/breed/breed.service';
+import { BreedTranslationService } from '../src/resources/breed-translation/breed-translation.service';
 import { FarmService } from '../src/resources/farm/farm.service';
 import { FarmMemberService } from '../src/resources/farm-member/farm-member.service';
 import { InvitationService } from '../src/resources/invitation/invitation.service';
@@ -24,6 +25,7 @@ declare module 'fastify' {
 		animalMeasurementService: AnimalMeasurementService;
 		authService: AuthService;
 		breedService: BreedService;
+		breedTranslationService: BreedTranslationService;
 		farmService: FarmService;
 		farmMemberService: FarmMemberService;
 		invitationService: InvitationService;


### PR DESCRIPTION
Move breed name from breeds table into a new breed_translation table, mirroring the existing species/species_translation pattern. Breeds are now created with an initial translation and additional languages can be added via the new breed-translations endpoint.

- Add breed_translation migration and remove name from breeds
- Create breed-translation resource (model, schema, service, serializer, routes)
- Update breed resource to work with translations
- Update animal serializer/service to include breed translations
- Update seeder with en/es breed translations
- Update Bruno API docs for new request/response shapes