### PR TITLE
feat: add animal search endpoint

### DIFF
--- a/src/resources/animal/animal.routes.ts
+++ b/src/resources/animal/animal.routes.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
-import { AnimalCreate, AnimalUpdate, AnimalBulkCreate, AnimalInclude, AnimalParams, createAnimalSchema, listAnimalSchema, getAnimalByIdSchema, bulkCreateAnimalSchema, getAnimalDashboardSchema, updateAnimalSchema, deleteAnimalSchema } from './animal.schema';
+import { AnimalCreate, AnimalUpdate, AnimalBulkCreate, AnimalInclude, AnimalSearchQuery, AnimalParams, createAnimalSchema, listAnimalSchema, searchAnimalSchema, getAnimalByIdSchema, bulkCreateAnimalSchema, getAnimalDashboardSchema, updateAnimalSchema, deleteAnimalSchema } from './animal.schema';
 import { AnimalSerializer } from './animal.serializer';
 import { decodeId } from '../../utils/id-hash-util';
 import { UserLanguage } from '../user/user.schema';
@@ -14,6 +14,21 @@ const animalRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 			const filters = fastify.animalService.extractFilterParams(request.query);
 			const pagination = parsePagination(request.query);
 			const result = await fastify.animalService.getAnimals(farmId, language, include, filters, pagination);
+			const serializedAnimals = AnimalSerializer.serializeMany(result.rows);
+			reply.successWithPagination(serializedAnimals, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/search', { schema: searchAnimalSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{Querystring: AnimalSearchQuery}>, reply) => {
+		try {
+			const { q, include, language } = request.query;
+			const farmId = request.lastVisitedFarmId;
+			const filters = fastify.animalService.extractFilterParams(request.query);
+			delete filters.q;
+			const pagination = parsePagination(request.query);
+			const result = await fastify.animalService.searchAnimals(farmId, q, language, include, filters, pagination);
 			const serializedAnimals = AnimalSerializer.serializeMany(result.rows);
 			reply.successWithPagination(serializedAnimals, result.pagination);
 		} catch (error) {

--- a/src/resources/animal/animal.schema.ts
+++ b/src/resources/animal/animal.schema.ts
@@ -170,6 +170,15 @@ export const AnimalIncludeSchema = Type.Object({
 	...PaginationQueryProps,
 });
 
+export const AnimalSearchQuerySchema = Type.Object({
+	q: Type.String({ minLength: 1 }),
+	include: Type.Optional(Type.String()),
+	language: Type.Enum(UserLanguage),
+	sex: Type.Optional(Type.Enum(AnimalSex)),
+	speciesId: Type.Optional(Type.String()),
+	...PaginationQueryProps,
+});
+
 export const AnimalParamsSchema = Type.Object({
 	id: Type.String(),
 });
@@ -180,6 +189,7 @@ export type AnimalResponse = Static<typeof AnimalResponseSchema>;
 export type AnimalUpdate = Static<typeof AnimalUpdateSchema>;
 export type AnimalParams = Static<typeof AnimalParamsSchema>;
 export type AnimalInclude = Static<typeof AnimalIncludeSchema>;
+export type AnimalSearchQuery = Static<typeof AnimalSearchQuerySchema>;
 export type AnimalBulkCreate = Static<typeof AnimalBulkCreateSchema>;
 
 export const createAnimalSchema = createPostEndpointSchema({
@@ -192,6 +202,12 @@ export const listAnimalSchema = createListEndpointSchema({
 	querystring: AnimalIncludeSchema,
 	dataSchema: Type.Array(AnimalResponseSchema),
 	errorCodes: [404],
+});
+
+export const searchAnimalSchema = createListEndpointSchema({
+	querystring: AnimalSearchQuerySchema,
+	dataSchema: Type.Array(AnimalResponseSchema),
+	errorCodes: [400],
 });
 
 export const getAnimalByIdSchema = createGetEndpointSchema({

--- a/src/resources/animal/animal.service.ts
+++ b/src/resources/animal/animal.service.ts
@@ -86,6 +86,36 @@ export class AnimalService extends BaseService {
 		return this.findAllPaginated(this.db.models.Animal, findOptions, pagination!);
 	}
 
+	async searchAnimals(farmId: number, searchTerm: string, language: UserLanguage, includeParam?: string, filters?: Record<string, string>, pagination?: PaginationParams): Promise<PaginatedResult<AnimalModel>> {
+		let includes = this.parseIncludes(includeParam, AnimalService.ALLOWED_INCLUDES);
+		const filterWhere = this.parseFilters(filters, AnimalService.ALLOWED_FILTERS);
+
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
+			includes = this.filterTranslationsByLanguage(includes, language);
+		}
+
+		const searchWhere = {
+			[Op.or]: [
+				{ name: { [Op.iLike]: `%${searchTerm}%` } },
+				{ tagNumber: { [Op.iLike]: `%${searchTerm}%` } },
+				{ groupName: { [Op.iLike]: `%${searchTerm}%` } },
+			],
+		};
+
+		const findOptions: FindOptions = {
+			where: {
+				[Op.and]: [
+					{ farmId },
+					searchWhere,
+					filterWhere,
+				],
+			},
+			include: includes,
+		};
+
+		return this.findAllPaginated(this.db.models.Animal, findOptions, pagination!);
+	}
+
 	async createAnimal({ data, language }: { data: AnimalCreate & { farmId: number }, language: UserLanguage }): Promise<AnimalModel | null> {
 		return this.db.sequelize.transaction(async (transaction) => {
 			const { breedId, speciesId, fatherId, motherId } = await this.decodeAnimalIds(data);

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -59,7 +59,7 @@ export async function createAnimal(
 	farmId: number,
 	speciesId: number,
 	breedId: number,
-	overrides?: { tagNumber?: string; name?: string; sex?: string },
+	overrides?: { tagNumber?: string; name?: string; sex?: string; groupName?: string },
 ): Promise<{ animalId: number; encodedAnimalId: string }> {
 	const animal = await app.db.models.Animal.create({
 		farmId,
@@ -68,6 +68,7 @@ export async function createAnimal(
 		tagNumber: overrides?.tagNumber ?? `TAG-${Date.now()}`,
 		name: overrides?.name ?? 'Test Animal',
 		sex: overrides?.sex ?? 'unknown',
+		...(overrides?.groupName ? { groupName: overrides.groupName } : {}),
 	});
 
 	return {

--- a/tests/integration/animal.test.ts
+++ b/tests/integration/animal.test.ts
@@ -93,6 +93,162 @@ describe('Animal endpoints', () => {
 		});
 	});
 
+	describe('GET /api/v1/animals/search', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=test&language=en',
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('returns 400 when q parameter is missing', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?language=en',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('matches animals by name', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-001', name: 'Dolly' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-002', name: 'Molly' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-003', name: 'Berta' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=olly&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('matches animals by tagNumber', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'TAG-100', name: 'Alpha' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'TAG-200', name: 'Beta' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'OTHER-001', name: 'Gamma' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=TAG&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('matches animals by groupName', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-001', groupName: 'Barn A' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-002', groupName: 'Barn B' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-003', groupName: 'Pasture' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=barn&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('is case-insensitive', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'CI-001', name: 'DOLLY' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=dolly&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+		});
+
+		it('combines search with sex filter', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'SF-001', name: 'Dolly', sex: 'female' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'SF-002', name: 'Dollar', sex: 'male' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=dol&sex=female&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].tagNumber).toBe('SF-001');
+		});
+
+		it('returns paginated search results', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-001', name: 'Sheep One' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-002', name: 'Sheep Two' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-003', name: 'Sheep Three' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=sheep&language=en&page=1&limit=2',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+			expect(body.meta.pagination.total).toBe(3);
+			expect(body.meta.pagination.totalPages).toBe(2);
+		});
+
+		it('returns empty results when no matches found', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'NM-001', name: 'Dolly' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=zzzznotfound&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(0);
+			expect(body.meta.pagination.total).toBe(0);
+		});
+	});
+
 	describe('POST /api/v1/animals', () => {
 		it('returns 401 when not authenticated with valid body', async () => {
 			const response = await app.inject({


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/animals/search?q=<term>` endpoint for case-insensitive text search across `name`, `tagNumber`, and `groupName` fields using `Op.iLike`
- Supports all existing filters (`sex`, `speciesId`, `groupName`), pagination, and includes
- Separate from the list endpoint to keep concerns clean and allow independent evolution

## Frontend Integration
- **Endpoint:** `GET /api/v1/animals/search`
- **Required params:** `q` (min 1 char), `language`
- **Optional params:** `include`, `sex`, `speciesId`, `page`, `limit`
- **Response:** Same paginated format as `GET /animals` — `data` array + `meta.pagination`
- **Example:** `GET /api/v1/animals/search?q=dolly&language=en&include=species.translations&page=1&limit=10`

## Test plan
- [ ] `GET /animals/search?q=dolly&language=en` — returns matching animals
- [ ] `GET /animals/search?q=001&sex=female&language=en` — search + filter combo
- [ ] `GET /animals/search?q=test&page=1&limit=5&language=en` — search + pagination
- [ ] `GET /animals/search?q=test&include=species.translations&language=en` — search + includes
- [ ] `GET /animals/search?language=en` — 400 error (q is required)
- [ ] Build passes: `docker compose exec app npm run build`