### PR TITLE
feat: add latest measurements endpoint and history deltas

### DIFF
--- a/src/resources/animal-measurement/animal-measurement.routes.ts
+++ b/src/resources/animal-measurement/animal-measurement.routes.ts
@@ -1,11 +1,21 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
-import { AnimalMeasurementParams, AnimalMeasurementDeleteParams, AnimalMeasurementCreate, listAnimalMeasurementsSchema, createAnimalMeasurementSchema, deleteAnimalMeasurementSchema, AnimalMeasurementQuery } from './animal-measurement.schema';
+import { AnimalMeasurementParams, AnimalMeasurementDeleteParams, AnimalMeasurementCreate, listAnimalMeasurementsSchema, latestAnimalMeasurementsSchema, createAnimalMeasurementSchema, deleteAnimalMeasurementSchema, AnimalMeasurementQuery } from './animal-measurement.schema';
 import { decodeId } from '../../utils/id-hash-util';
 import { AnimalMeasurementSerializer } from './animal-measurement.serializer';
 import { parsePagination } from '../../utils/pagination';
 
 const animalMeasurementRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
-	// Routes now use the decorated service instead of creating a new instance
+
+	fastify.get('/animals/:animalId/measurements/latest', { schema: latestAnimalMeasurementsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{Params: AnimalMeasurementParams}>, reply) => {
+		try {
+			const { animalId } = request.params;
+			const measurements = await fastify.animalMeasurementService.getLatestMeasurements(decodeId(animalId)!);
+			const serialized = AnimalMeasurementSerializer.serializeMany(measurements);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
 
 	fastify.get('/animals/:animalId/measurements', { schema: listAnimalMeasurementsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{Params: AnimalMeasurementParams, Querystring: AnimalMeasurementQuery}>, reply) => {
 		try {
@@ -13,7 +23,9 @@ const animalMeasurementRoutes: FastifyPluginAsync = async (fastify: FastifyInsta
 			const { measurementType } = request.query;
 			const pagination = parsePagination(request.query);
 			const result = await fastify.animalMeasurementService.getAnimalMeasurements(decodeId(animalId)!, '', { measurementType: measurementType as string }, pagination);
-			const serializedMeasurements = AnimalMeasurementSerializer.serializeMany(result.rows);
+			const serializedMeasurements = measurementType
+				? AnimalMeasurementSerializer.serializeManyWithDeltas(result.rows)
+				: AnimalMeasurementSerializer.serializeMany(result.rows).map(m => ({ ...m, change: null, changePercent: null }));
 			reply.successWithPagination(serializedMeasurements, result.pagination);
 		} catch (error) {
 			fastify.handleDbError(error, reply);

--- a/src/resources/animal-measurement/animal-measurement.schema.ts
+++ b/src/resources/animal-measurement/animal-measurement.schema.ts
@@ -1,6 +1,7 @@
 import { Static, Type } from '@sinclair/typebox';
 import {
 	createListEndpointSchema,
+	createGetEndpointSchema,
 	createPostEndpointSchema,
 	createDeleteEndpointSchema,
 } from '../../utils/schema-builder';
@@ -67,8 +68,21 @@ const AnimalMeasurementDeleteParamsSchema = Type.Object({
 	measurementId: Type.String(),
 });
 
+export const AnimalMeasurementWithDeltaResponseSchema = Type.Object(
+	{
+		...AnimalMeasurementResponseSchema.properties,
+		change: Type.Union([Type.Number(), Type.Null()]),
+		changePercent: Type.Union([Type.Number(), Type.Null()]),
+	},
+	{
+		$id: 'animalMeasurementWithDeltaResponse',
+		additionalProperties: false,
+	},
+);
+
 export type AnimalMeasurement = Static<typeof AnimalMeasurementSchema>;
 export type AnimalMeasurementResponse = Static<typeof AnimalMeasurementResponseSchema>;
+export type AnimalMeasurementWithDeltaResponse = Static<typeof AnimalMeasurementWithDeltaResponseSchema>;
 export type AnimalMeasurementParams = Static<typeof AnimalMeasurementParamsSchema>;
 export type AnimalMeasurementDeleteParams = Static<typeof AnimalMeasurementDeleteParamsSchema>;
 export type AnimalMeasurementCreate = Static<typeof AnimalMeasurementCreateSchema>;
@@ -90,9 +104,15 @@ const AnimalMeasurementCreateSchema = Type.Object(
 
 export const listAnimalMeasurementsSchema = createListEndpointSchema({
 	params: AnimalMeasurementParamsSchema,
-	dataSchema: Type.Array(AnimalMeasurementResponseSchema),
+	dataSchema: Type.Array(AnimalMeasurementWithDeltaResponseSchema),
 	errorCodes: [404],
 	querystring: AnimalMeasurementQuerySchema,
+});
+
+export const latestAnimalMeasurementsSchema = createGetEndpointSchema({
+	params: AnimalMeasurementParamsSchema,
+	dataSchema: Type.Array(AnimalMeasurementResponseSchema),
+	errorCodes: [404],
 });
 
 export const createAnimalMeasurementSchema = createPostEndpointSchema({

--- a/src/resources/animal-measurement/animal-measurement.serializer.ts
+++ b/src/resources/animal-measurement/animal-measurement.serializer.ts
@@ -1,5 +1,5 @@
 import { encodeId } from '../../utils/id-hash-util';
-import { AnimalMeasurementResponse } from './animal-measurement.schema';
+import { AnimalMeasurementResponse, AnimalMeasurementWithDeltaResponse } from './animal-measurement.schema';
 import { AnimalMeasurementModel } from './animal-measurement.model';
 
 export class AnimalMeasurementSerializer {
@@ -20,5 +20,30 @@ export class AnimalMeasurementSerializer {
 
 	static serializeMany(measurements: AnimalMeasurementModel[]): AnimalMeasurementResponse[] {
 		return measurements.map(m => this.serialize(m));
+	}
+
+	static serializeManyWithDeltas(measurements: AnimalMeasurementModel[]): AnimalMeasurementWithDeltaResponse[] {
+		// Sort chronologically (oldest first) to compute deltas forward
+		const sorted = [...measurements].sort(
+			(a, b) => new Date(a.measuredAt).getTime() - new Date(b.measuredAt).getTime(),
+		);
+
+		const withDeltas: AnimalMeasurementWithDeltaResponse[] = sorted.map((measurement, index) => {
+			const base = this.serialize(measurement);
+			if (index === 0) {
+				return { ...base, change: null, changePercent: null };
+			}
+
+			const previousValue = sorted[index - 1]!.value;
+			const change = Number((measurement.value - previousValue).toFixed(2));
+			const changePercent = previousValue !== 0
+				? Number((((measurement.value - previousValue) / previousValue) * 100).toFixed(2))
+				: null;
+
+			return { ...base, change, changePercent };
+		});
+
+		// Reverse back to DESC order (newest first) to match the API response order
+		return withDeltas.reverse();
 	}
 }

--- a/src/resources/animal-measurement/animal-measurement.service.ts
+++ b/src/resources/animal-measurement/animal-measurement.service.ts
@@ -34,6 +34,25 @@ export class AnimalMeasurementService extends BaseService {
 		return this.findAllPaginated(this.db.models.AnimalMeasurement, findOptions, pagination!);
 	}
 
+	async getLatestMeasurements(animalId: number): Promise<AnimalMeasurementModel[]> {
+		const measurements = await this.db.models.AnimalMeasurement.findAll({
+			where: { animalId },
+			order: [['measuredAt', 'DESC']],
+		});
+
+		const seen = new Set<AnimalMeasurementType>();
+		const latest: AnimalMeasurementModel[] = [];
+
+		for (const measurement of measurements) {
+			if (!seen.has(measurement.measurementType)) {
+				seen.add(measurement.measurementType);
+				latest.push(measurement);
+			}
+		}
+
+		return latest;
+	}
+
 	async createAnimalMeasurement({ animalId, data, userId }: {
 		animalId: number;
 		data: AnimalMeasurementCreate;

--- a/src/resources/animal/animal.routes.ts
+++ b/src/resources/animal/animal.routes.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
-import { AnimalCreate, AnimalUpdate, AnimalBulkCreate, AnimalInclude, AnimalParams, createAnimalSchema, listAnimalSchema, getAnimalByIdSchema, bulkCreateAnimalSchema, getAnimalDashboardSchema, updateAnimalSchema, deleteAnimalSchema } from './animal.schema';
+import { AnimalCreate, AnimalUpdate, AnimalBulkCreate, AnimalInclude, AnimalSearchQuery, AnimalParams, createAnimalSchema, listAnimalSchema, searchAnimalSchema, getAnimalByIdSchema, bulkCreateAnimalSchema, getAnimalDashboardSchema, updateAnimalSchema, deleteAnimalSchema } from './animal.schema';
 import { AnimalSerializer } from './animal.serializer';
 import { decodeId } from '../../utils/id-hash-util';
 import { UserLanguage } from '../user/user.schema';
@@ -14,6 +14,21 @@ const animalRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 			const filters = fastify.animalService.extractFilterParams(request.query);
 			const pagination = parsePagination(request.query);
 			const result = await fastify.animalService.getAnimals(farmId, language, include, filters, pagination);
+			const serializedAnimals = AnimalSerializer.serializeMany(result.rows);
+			reply.successWithPagination(serializedAnimals, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/search', { schema: searchAnimalSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{Querystring: AnimalSearchQuery}>, reply) => {
+		try {
+			const { q, include, language } = request.query;
+			const farmId = request.lastVisitedFarmId;
+			const filters = fastify.animalService.extractFilterParams(request.query);
+			delete filters.q;
+			const pagination = parsePagination(request.query);
+			const result = await fastify.animalService.searchAnimals(farmId, q, language, include, filters, pagination);
 			const serializedAnimals = AnimalSerializer.serializeMany(result.rows);
 			reply.successWithPagination(serializedAnimals, result.pagination);
 		} catch (error) {

--- a/src/resources/animal/animal.schema.ts
+++ b/src/resources/animal/animal.schema.ts
@@ -170,6 +170,15 @@ export const AnimalIncludeSchema = Type.Object({
 	...PaginationQueryProps,
 });
 
+export const AnimalSearchQuerySchema = Type.Object({
+	q: Type.String({ minLength: 1 }),
+	include: Type.Optional(Type.String()),
+	language: Type.Enum(UserLanguage),
+	sex: Type.Optional(Type.Enum(AnimalSex)),
+	speciesId: Type.Optional(Type.String()),
+	...PaginationQueryProps,
+});
+
 export const AnimalParamsSchema = Type.Object({
 	id: Type.String(),
 });
@@ -180,6 +189,7 @@ export type AnimalResponse = Static<typeof AnimalResponseSchema>;
 export type AnimalUpdate = Static<typeof AnimalUpdateSchema>;
 export type AnimalParams = Static<typeof AnimalParamsSchema>;
 export type AnimalInclude = Static<typeof AnimalIncludeSchema>;
+export type AnimalSearchQuery = Static<typeof AnimalSearchQuerySchema>;
 export type AnimalBulkCreate = Static<typeof AnimalBulkCreateSchema>;
 
 export const createAnimalSchema = createPostEndpointSchema({
@@ -192,6 +202,12 @@ export const listAnimalSchema = createListEndpointSchema({
 	querystring: AnimalIncludeSchema,
 	dataSchema: Type.Array(AnimalResponseSchema),
 	errorCodes: [404],
+});
+
+export const searchAnimalSchema = createListEndpointSchema({
+	querystring: AnimalSearchQuerySchema,
+	dataSchema: Type.Array(AnimalResponseSchema),
+	errorCodes: [400],
 });
 
 export const getAnimalByIdSchema = createGetEndpointSchema({

--- a/src/resources/animal/animal.service.ts
+++ b/src/resources/animal/animal.service.ts
@@ -86,6 +86,36 @@ export class AnimalService extends BaseService {
 		return this.findAllPaginated(this.db.models.Animal, findOptions, pagination!);
 	}
 
+	async searchAnimals(farmId: number, searchTerm: string, language: UserLanguage, includeParam?: string, filters?: Record<string, string>, pagination?: PaginationParams): Promise<PaginatedResult<AnimalModel>> {
+		let includes = this.parseIncludes(includeParam, AnimalService.ALLOWED_INCLUDES);
+		const filterWhere = this.parseFilters(filters, AnimalService.ALLOWED_FILTERS);
+
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
+			includes = this.filterTranslationsByLanguage(includes, language);
+		}
+
+		const searchWhere = {
+			[Op.or]: [
+				{ name: { [Op.iLike]: `%${searchTerm}%` } },
+				{ tagNumber: { [Op.iLike]: `%${searchTerm}%` } },
+				{ groupName: { [Op.iLike]: `%${searchTerm}%` } },
+			],
+		};
+
+		const findOptions: FindOptions = {
+			where: {
+				[Op.and]: [
+					{ farmId },
+					searchWhere,
+					filterWhere,
+				],
+			},
+			include: includes,
+		};
+
+		return this.findAllPaginated(this.db.models.Animal, findOptions, pagination!);
+	}
+
 	async createAnimal({ data, language }: { data: AnimalCreate & { farmId: number }, language: UserLanguage }): Promise<AnimalModel | null> {
 		return this.db.sequelize.transaction(async (transaction) => {
 			const { breedId, speciesId, fatherId, motherId } = await this.decodeAnimalIds(data);

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -77,6 +77,28 @@ export async function createAnimal(
 	};
 }
 
+export async function createMeasurement(
+	app: FastifyInstance,
+	animalId: number,
+	measuredBy: number,
+	overrides?: { measurementType?: string; value?: number; unit?: string; measuredAt?: string; notes?: string },
+): Promise<{ measurementId: number; encodedMeasurementId: string }> {
+	const measurement = await app.db.models.AnimalMeasurement.create({
+		animalId,
+		measurementType: overrides?.measurementType ?? 'weight',
+		value: overrides?.value ?? 50.0,
+		unit: overrides?.unit ?? 'kg',
+		measuredAt: overrides?.measuredAt ?? new Date().toISOString(),
+		measuredBy,
+		notes: overrides?.notes,
+	});
+
+	return {
+		measurementId: measurement.dataValues.id,
+		encodedMeasurementId: encodeId(measurement.dataValues.id),
+	};
+}
+
 export async function createExpense(
 	app: FastifyInstance,
 	farmId: number,

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -59,7 +59,7 @@ export async function createAnimal(
 	farmId: number,
 	speciesId: number,
 	breedId: number,
-	overrides?: { tagNumber?: string; name?: string; sex?: string },
+	overrides?: { tagNumber?: string; name?: string; sex?: string; groupName?: string },
 ): Promise<{ animalId: number; encodedAnimalId: string }> {
 	const animal = await app.db.models.Animal.create({
 		farmId,
@@ -68,6 +68,7 @@ export async function createAnimal(
 		tagNumber: overrides?.tagNumber ?? `TAG-${Date.now()}`,
 		name: overrides?.name ?? 'Test Animal',
 		sex: overrides?.sex ?? 'unknown',
+		...(overrides?.groupName ? { groupName: overrides.groupName } : {}),
 	});
 
 	return {

--- a/tests/integration/animal-measurement.test.ts
+++ b/tests/integration/animal-measurement.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import { createSpecies, createBreed, createAnimal, createMeasurement } from '../helpers/factories';
+
+describe('Animal Measurement endpoints', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('GET /api/v1/animals/:animalId/measurements/latest', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/fakeid/measurements/latest',
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('returns empty array when animal has no measurements', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements/latest`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.data).toHaveLength(0);
+		});
+
+		it('returns latest measurement per type', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { animalId, encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			// Create older weight
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 40, unit: 'kg', measuredAt: '2025-01-01T00:00:00Z',
+			});
+			// Create newer weight (should be returned)
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 50, unit: 'kg', measuredAt: '2025-06-01T00:00:00Z',
+			});
+			// Create a height measurement
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'height', value: 80, unit: 'cm', measuredAt: '2025-03-01T00:00:00Z',
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements/latest`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+
+			const types = body.data.map((m: { measurementType: string }) => m.measurementType).sort();
+			expect(types).toEqual(['height', 'weight']);
+
+			const weight = body.data.find((m: { measurementType: string }) => m.measurementType === 'weight');
+			expect(weight.value).toBe(50);
+		});
+
+		it('returns only types with data', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { animalId, encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'temperature', value: 38.5, unit: 'celsius', measuredAt: '2025-01-01T00:00:00Z',
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements/latest`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].measurementType).toBe('temperature');
+			expect(body.data[0].value).toBe(38.5);
+		});
+	});
+
+	describe('GET /api/v1/animals/:animalId/measurements (history with deltas)', () => {
+		it('returns change and changePercent when measurementType filter is provided', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { animalId, encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 40, unit: 'kg', measuredAt: '2025-01-01T00:00:00Z',
+			});
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 50, unit: 'kg', measuredAt: '2025-02-01T00:00:00Z',
+			});
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 45, unit: 'kg', measuredAt: '2025-03-01T00:00:00Z',
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements?measurementType=weight`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(3);
+
+			// Results are DESC order (newest first)
+			// Most recent: 45kg (change from 50 = -5)
+			expect(body.data[0].value).toBe(45);
+			expect(body.data[0].change).toBe(-5);
+			expect(body.data[0].changePercent).toBe(-10);
+
+			// Middle: 50kg (change from 40 = +10)
+			expect(body.data[1].value).toBe(50);
+			expect(body.data[1].change).toBe(10);
+			expect(body.data[1].changePercent).toBe(25);
+		});
+
+		it('first (oldest) measurement has null change and changePercent', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { animalId, encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 40, unit: 'kg', measuredAt: '2025-01-01T00:00:00Z',
+			});
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 50, unit: 'kg', measuredAt: '2025-02-01T00:00:00Z',
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements?measurementType=weight`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+
+			// Oldest measurement (last in DESC order) has null deltas
+			const oldest = body.data[body.data.length - 1];
+			expect(oldest.value).toBe(40);
+			expect(oldest.change).toBeNull();
+			expect(oldest.changePercent).toBeNull();
+		});
+
+		it('does not include deltas when no measurementType filter', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { animalId, encodedAnimalId } = await createAnimal(app, user.farmId, speciesId, breedId);
+
+			await createMeasurement(app, animalId, user.id, {
+				measurementType: 'weight', value: 40, unit: 'kg', measuredAt: '2025-01-01T00:00:00Z',
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/animals/${encodedAnimalId}/measurements`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data[0].change).toBeNull();
+			expect(body.data[0].changePercent).toBeNull();
+		});
+	});
+});

--- a/tests/integration/animal.test.ts
+++ b/tests/integration/animal.test.ts
@@ -93,6 +93,162 @@ describe('Animal endpoints', () => {
 		});
 	});
 
+	describe('GET /api/v1/animals/search', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=test&language=en',
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('returns 400 when q parameter is missing', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?language=en',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('matches animals by name', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-001', name: 'Dolly' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-002', name: 'Molly' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'S-003', name: 'Berta' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=olly&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('matches animals by tagNumber', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'TAG-100', name: 'Alpha' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'TAG-200', name: 'Beta' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'OTHER-001', name: 'Gamma' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=TAG&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('matches animals by groupName', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-001', groupName: 'Barn A' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-002', groupName: 'Barn B' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'G-003', groupName: 'Pasture' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=barn&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+		});
+
+		it('is case-insensitive', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'CI-001', name: 'DOLLY' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=dolly&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+		});
+
+		it('combines search with sex filter', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'SF-001', name: 'Dolly', sex: 'female' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'SF-002', name: 'Dollar', sex: 'male' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=dol&sex=female&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].tagNumber).toBe('SF-001');
+		});
+
+		it('returns paginated search results', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-001', name: 'Sheep One' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-002', name: 'Sheep Two' });
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'P-003', name: 'Sheep Three' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=sheep&language=en&page=1&limit=2',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+			expect(body.meta.pagination.total).toBe(3);
+			expect(body.meta.pagination.totalPages).toBe(2);
+		});
+
+		it('returns empty results when no matches found', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createAnimal(app, user.farmId, speciesId, breedId, { tagNumber: 'NM-001', name: 'Dolly' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/animals/search?q=zzzznotfound&language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(0);
+			expect(body.meta.pagination.total).toBe(0);
+		});
+	});
+
 	describe('POST /api/v1/animals', () => {
 		it('returns 401 when not authenticated with valid body', async () => {
 			const response = await app.inject({


### PR DESCRIPTION
## Summary
- Add `GET /animals/:animalId/measurements/latest` endpoint that returns the most recent measurement per type (weight, height, temperature) for animal summary views
- Add computed `change` and `changePercent` delta fields to the existing list endpoint when filtered by `measurementType`, enabling the UI to show measurement evolution server-side
- Add `createMeasurement` test factory and 7 integration tests covering both features

## Test plan
- [x] Build passes (`docker compose exec app npm run build`)
- [x] All 113 tests pass (`docker compose exec app npm run test`)
- [x] Manual: `GET /api/v1/animals/:id/measurements/latest` returns latest per type
- [x] Manual: `GET /api/v1/animals/:id/measurements?measurementType=weight` returns history with deltas
- [x] Manual: `GET /api/v1/animals/:id/measurements` returns list without deltas (null change/changePercent)