### PR TITLE
feat(flock): add flock management resources with tests

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -19,6 +19,12 @@ import {
 	initAnimalMeasurementModel,
 } from '../resources/animal-measurement/animal-measurement.model';
 import { ExpenseModel, initExpenseModel } from '../resources/expense/expense.model';
+import { FlockModel, initFlockModel } from '../resources/flock/flock.model';
+import { FlockEventModel, initFlockEventModel } from '../resources/flock-event/flock-event.model';
+import {
+	EggCollectionModel,
+	initEggCollectionModel,
+} from '../resources/egg-collection/egg-collection.model';
 
 export interface Database {
 	sequelize: Sequelize;
@@ -34,6 +40,9 @@ export interface Database {
 		Animal: typeof AnimalModel;
 		AnimalMeasurement: typeof AnimalMeasurementModel;
 		Expense: typeof ExpenseModel;
+		Flock: typeof FlockModel;
+		FlockEvent: typeof FlockEventModel;
+		EggCollection: typeof EggCollectionModel;
 	};
 }
 
@@ -75,6 +84,9 @@ export const initDatabase = async (): Promise<Database> => {
 	const Animal = initAnimalModel(sequelize);
 	const AnimalMeasurement = initAnimalMeasurementModel(sequelize);
 	const Expense = initExpenseModel(sequelize);
+	const Flock = initFlockModel(sequelize);
+	const FlockEvent = initFlockEventModel(sequelize);
+	const EggCollection = initEggCollectionModel(sequelize);
 
 	// associations
 	// Farm & FarmMembers
@@ -116,6 +128,24 @@ export const initDatabase = async (): Promise<Database> => {
 	Expense.belongsTo(UserModel, { foreignKey: 'createdBy', as: 'creator' });
 	FarmModel.hasMany(Expense, { foreignKey: 'farmId', as: 'expenses' });
 
+	// Flock associations
+	Flock.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
+	Flock.belongsTo(Species, { foreignKey: 'speciesId', as: 'species' });
+	Flock.belongsTo(Breed, { foreignKey: 'breedId', as: 'breed' });
+	FarmModel.hasMany(Flock, { foreignKey: 'farmId', as: 'flocks' });
+	Species.hasMany(Flock, { foreignKey: 'speciesId', as: 'flocks' });
+	Breed.hasMany(Flock, { foreignKey: 'breedId', as: 'flocksByBreed' });
+
+	// FlockEvent associations
+	FlockEvent.belongsTo(Flock, { foreignKey: 'flockId', as: 'flock' });
+	FlockEvent.belongsTo(UserModel, { foreignKey: 'recordedBy', as: 'recorder' });
+	Flock.hasMany(FlockEvent, { foreignKey: 'flockId', as: 'events' });
+
+	// EggCollection associations
+	EggCollection.belongsTo(Flock, { foreignKey: 'flockId', as: 'flock' });
+	EggCollection.belongsTo(UserModel, { foreignKey: 'collectedBy', as: 'collector' });
+	Flock.hasMany(EggCollection, { foreignKey: 'flockId', as: 'eggCollections' });
+
 	const db: Database = {
 		sequelize,
 		models: {
@@ -130,6 +160,9 @@ export const initDatabase = async (): Promise<Database> => {
 			Animal,
 			AnimalMeasurement,
 			Expense,
+			Flock,
+			FlockEvent,
+			EggCollection,
 		},
 	};
 

--- a/src/migrations/20260320120000-create-flocks-table-migration.js
+++ b/src/migrations/20260320120000-create-flocks-table-migration.js
@@ -1,0 +1,117 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('flocks', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			farm_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'farms',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			species_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'species',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			breed_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'breeds',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			name: {
+				type: Sequelize.STRING,
+				allowNull: false,
+			},
+			flock_type: {
+				type: Sequelize.ENUM('layers', 'broilers', 'dual_purpose', 'general'),
+				allowNull: false,
+			},
+			initial_count: {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+			},
+			current_count: {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+			},
+			status: {
+				type: Sequelize.ENUM('active', 'sold', 'culled', 'completed'),
+				allowNull: false,
+				defaultValue: 'active',
+			},
+			start_date: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			end_date: {
+				type: Sequelize.DATEONLY,
+				allowNull: true,
+			},
+			house_name: {
+				type: Sequelize.STRING,
+				allowNull: true,
+			},
+			acquisition_type: {
+				type: Sequelize.ENUM('hatched', 'purchased', 'other'),
+				allowNull: false,
+			},
+			age_at_acquisition_weeks: {
+				type: Sequelize.INTEGER,
+				allowNull: true,
+			},
+			notes: {
+				type: Sequelize.TEXT,
+				allowNull: true,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.addIndex('flocks', ['farm_id', 'name'], {
+			unique: true,
+			name: 'idx_flocks_farm_name_unique',
+		});
+		await queryInterface.addIndex('flocks', ['farm_id', 'status'], {
+			name: 'idx_flocks_farm_status',
+		});
+		await queryInterface.addIndex('flocks', ['farm_id', 'species_id'], {
+			name: 'idx_flocks_farm_species',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('flocks', 'idx_flocks_farm_name_unique');
+		await queryInterface.removeIndex('flocks', 'idx_flocks_farm_status');
+		await queryInterface.removeIndex('flocks', 'idx_flocks_farm_species');
+		await queryInterface.dropTable('flocks');
+	},
+};

--- a/src/migrations/20260320120001-create-flock-events-table-migration.js
+++ b/src/migrations/20260320120001-create-flock-events-table-migration.js
@@ -1,0 +1,73 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('flock_events', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			flock_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'flocks',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			event_type: {
+				type: Sequelize.ENUM('mortality', 'sale', 'cull', 'addition', 'transfer'),
+				allowNull: false,
+			},
+			count: {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+			},
+			date: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			reason: {
+				type: Sequelize.STRING,
+				allowNull: true,
+			},
+			recorded_by: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: true,
+				references: {
+					model: 'users',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'SET NULL',
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.addIndex('flock_events', ['flock_id', 'date'], {
+			name: 'idx_flock_events_flock_date',
+		});
+		await queryInterface.addIndex('flock_events', ['flock_id', 'event_type'], {
+			name: 'idx_flock_events_flock_type',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('flock_events', 'idx_flock_events_flock_date');
+		await queryInterface.removeIndex('flock_events', 'idx_flock_events_flock_type');
+		await queryInterface.dropTable('flock_events');
+	},
+};

--- a/src/migrations/20260320120002-create-egg-collections-table-migration.js
+++ b/src/migrations/20260320120002-create-egg-collections-table-migration.js
@@ -1,0 +1,71 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('egg_collections', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			flock_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: {
+					model: 'flocks',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			date: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			total_eggs: {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+			},
+			broken_eggs: {
+				type: Sequelize.INTEGER,
+				allowNull: false,
+				defaultValue: 0,
+			},
+			collected_by: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: true,
+				references: {
+					model: 'users',
+					key: 'id',
+				},
+				onUpdate: 'CASCADE',
+				onDelete: 'SET NULL',
+			},
+			notes: {
+				type: Sequelize.TEXT,
+				allowNull: true,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.addIndex('egg_collections', ['flock_id', 'date'], {
+			unique: true,
+			name: 'idx_egg_collections_flock_date_unique',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('egg_collections', 'idx_egg_collections_flock_date_unique');
+		await queryInterface.dropTable('egg_collections');
+	},
+};

--- a/src/migrations/20260320130000-add-chicken-species-breeds-migration.js
+++ b/src/migrations/20260320130000-add-chicken-species-breeds-migration.js
@@ -1,0 +1,83 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface) => {
+		const now = new Date();
+
+		// Check if Chicken species already exists
+		const [existing] = await queryInterface.sequelize.query(
+			`SELECT s.id FROM species s
+			 JOIN species_translation st ON st.species_id = s.id
+			 WHERE st.language_code = 'en' AND st.name = 'Chicken'`,
+		);
+		if (existing.length > 0) return;
+
+		// Create species row
+		const [speciesRows] = await queryInterface.sequelize.query(
+			`INSERT INTO species (created_at, updated_at)
+			 VALUES (:now, :now)
+			 RETURNING id`,
+			{ replacements: { now } },
+		);
+		const chickenId = speciesRows[0].id;
+
+		// Species translations
+		await queryInterface.bulkInsert('species_translation', [
+			{ species_id: chickenId, language_code: 'en', name: 'Chicken', created_at: now, updated_at: now },
+			{ species_id: chickenId, language_code: 'es', name: 'Pollo', created_at: now, updated_at: now },
+		]);
+
+		// Breeds
+		const breedData = [
+			{ en: 'Leghorn', es: 'Leghorn' },
+			{ en: 'Rhode Island Red', es: 'Rhode Island Red' },
+			{ en: 'Plymouth Rock', es: 'Plymouth Rock' },
+			{ en: 'Other', es: 'Otro' },
+		];
+
+		for (const breed of breedData) {
+			const [breedRows] = await queryInterface.sequelize.query(
+				`INSERT INTO breeds (species_id, created_at, updated_at)
+				 VALUES (:chickenId, :now, :now)
+				 RETURNING id`,
+				{ replacements: { chickenId, now } },
+			);
+			const breedId = breedRows[0].id;
+
+			await queryInterface.bulkInsert('breed_translation', [
+				{ breed_id: breedId, language_code: 'en', name: breed.en, created_at: now, updated_at: now },
+				{ breed_id: breedId, language_code: 'es', name: breed.es, created_at: now, updated_at: now },
+			]);
+		}
+	},
+
+	down: async (queryInterface) => {
+		// Find the chicken species ID
+		const [rows] = await queryInterface.sequelize.query(
+			`SELECT s.id FROM species s
+			 JOIN species_translation st ON st.species_id = s.id
+			 WHERE st.language_code = 'en' AND st.name = 'Chicken'`,
+		);
+		if (rows.length === 0) return;
+
+		const chickenId = rows[0].id;
+
+		// Cascade: breed_translation → breeds → species_translation → species
+		await queryInterface.sequelize.query(
+			`DELETE FROM breed_translation WHERE breed_id IN (SELECT id FROM breeds WHERE species_id = :chickenId)`,
+			{ replacements: { chickenId } },
+		);
+		await queryInterface.sequelize.query(
+			`DELETE FROM breeds WHERE species_id = :chickenId`,
+			{ replacements: { chickenId } },
+		);
+		await queryInterface.sequelize.query(
+			`DELETE FROM species_translation WHERE species_id = :chickenId`,
+			{ replacements: { chickenId } },
+		);
+		await queryInterface.sequelize.query(
+			`DELETE FROM species WHERE id = :chickenId`,
+			{ replacements: { chickenId } },
+		);
+	},
+};

--- a/src/plugins/services.plugin.ts
+++ b/src/plugins/services.plugin.ts
@@ -14,6 +14,9 @@ import { InvitationService } from '../resources/invitation/invitation.service';
 import { SpeciesService } from '../resources/species/species.service';
 import { SpeciesTranslationService } from '../resources/species-translation/species-translation.service';
 import { UserService } from '../resources/user/user.service';
+import { FlockService } from '../resources/flock/flock.service';
+import { FlockEventService } from '../resources/flock-event/flock-event.service';
+import { EggCollectionService } from '../resources/egg-collection/egg-collection.service';
 
 const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	// Register all services as Fastify decorators
@@ -31,6 +34,9 @@ const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	fastify.decorate('speciesService', new SpeciesService(fastify.db));
 	fastify.decorate('speciesTranslationService', new SpeciesTranslationService(fastify.db));
 	fastify.decorate('userService', new UserService(fastify.db));
+	fastify.decorate('flockService', new FlockService(fastify.db));
+	fastify.decorate('flockEventService', new FlockEventService(fastify.db));
+	fastify.decorate('eggCollectionService', new EggCollectionService(fastify.db));
 
 	fastify.log.info('Services plugin registered successfully');
 };

--- a/src/resources/egg-collection/egg-collection.model.ts
+++ b/src/resources/egg-collection/egg-collection.model.ts
@@ -1,0 +1,82 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { EggCollection } from './egg-collection.schema';
+
+type EggCollectionCreationAttributes = Pick<EggCollection, 'flockId' | 'date' | 'totalEggs'> & Partial<Pick<EggCollection, 'brokenEggs' | 'collectedBy' | 'notes'>>;
+
+export class EggCollectionModel extends Model<EggCollection, EggCollectionCreationAttributes> {
+	declare id: number;
+	declare flockId: number;
+	declare date: string;
+	declare totalEggs: number;
+	declare brokenEggs: number;
+	declare collectedBy: number | null;
+	declare notes: string | null;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initEggCollectionModel = (sequelize: Sequelize) => EggCollectionModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	flockId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'flock_id',
+		references: { model: 'flocks', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	date: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+	},
+	totalEggs: {
+		type: DataTypes.INTEGER,
+		allowNull: false,
+		field: 'total_eggs',
+	},
+	brokenEggs: {
+		type: DataTypes.INTEGER,
+		allowNull: false,
+		field: 'broken_eggs',
+		defaultValue: 0,
+	},
+	collectedBy: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: true,
+		field: 'collected_by',
+		references: { model: 'users', key: 'id' },
+		onDelete: 'SET NULL',
+	},
+	notes: {
+		type: DataTypes.TEXT,
+		allowNull: true,
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'egg_collections',
+	modelName: 'EggCollection',
+	timestamps: true,
+	indexes: [
+		{
+			unique: true,
+			fields: ['flock_id', 'date'],
+			name: 'idx_egg_collections_flock_date_unique',
+		},
+	],
+});

--- a/src/resources/egg-collection/egg-collection.routes.ts
+++ b/src/resources/egg-collection/egg-collection.routes.ts
@@ -1,0 +1,92 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import {
+	EggCollectionParams,
+	EggCollectionItemParams,
+	EggCollectionCreate,
+	EggCollectionUpdate,
+	EggCollectionQuery,
+	listEggCollectionsSchema,
+	createEggCollectionSchema,
+	updateEggCollectionSchema,
+	deleteEggCollectionSchema,
+} from './egg-collection.schema';
+import { decodeId } from '../../utils/id-hash-util';
+import { EggCollectionSerializer } from './egg-collection.serializer';
+import { parsePagination } from '../../utils/pagination';
+
+const eggCollectionRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/flocks/:flockId/egg-collections', { schema: listEggCollectionsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: EggCollectionParams, Querystring: EggCollectionQuery }>, reply) => {
+		try {
+			const { flockId } = request.params;
+			const decodedFlockId = decodeId(flockId)!;
+			const pagination = parsePagination(request.query);
+
+			const flock = await fastify.flockService.getFlockById(decodedFlockId, 'EN' as never);
+			if (!flock) {
+				return reply.error('Flock not found', 404);
+			}
+
+			const result = await fastify.eggCollectionService.getEggCollections(decodedFlockId, pagination);
+			const serialized = EggCollectionSerializer.serializeMany(result.rows, flock.currentCount);
+			reply.successWithPagination(serialized, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/flocks/:flockId/egg-collections', { schema: createEggCollectionSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: EggCollectionParams, Body: EggCollectionCreate }>, reply) => {
+		try {
+			const { flockId } = request.params;
+			const userId = request.user!.id;
+			const decodedFlockId = decodeId(flockId)!;
+
+			const collection = await fastify.eggCollectionService.createEggCollection({
+				flockId: decodedFlockId,
+				data: request.body,
+				userId,
+			});
+
+			const flock = await fastify.flockService.getFlockById(decodedFlockId, 'EN' as never);
+			const serialized = EggCollectionSerializer.serialize(collection, flock!.currentCount);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.put('/flocks/:flockId/egg-collections/:id', { schema: updateEggCollectionSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: EggCollectionItemParams, Body: EggCollectionUpdate }>, reply) => {
+		try {
+			const { flockId, id } = request.params;
+			const decodedFlockId = decodeId(flockId)!;
+			const collectionId = decodeId(id)!;
+
+			const collection = await fastify.eggCollectionService.updateEggCollection({
+				flockId: decodedFlockId,
+				collectionId,
+				data: request.body,
+			});
+
+			const flock = await fastify.flockService.getFlockById(decodedFlockId, 'EN' as never);
+			const serialized = EggCollectionSerializer.serialize(collection, flock!.currentCount);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/flocks/:flockId/egg-collections/:id', { schema: deleteEggCollectionSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: EggCollectionItemParams }>, reply) => {
+		try {
+			const { flockId, id } = request.params;
+			await fastify.eggCollectionService.deleteEggCollection({
+				flockId: decodeId(flockId)!,
+				collectionId: decodeId(id)!,
+			});
+			reply.success(null);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default eggCollectionRoutes;

--- a/src/resources/egg-collection/egg-collection.schema.ts
+++ b/src/resources/egg-collection/egg-collection.schema.ts
@@ -1,0 +1,104 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createUpdateEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+const EggCollectionSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	flockId: Type.Integer(),
+	date: Type.String(),
+	totalEggs: Type.Integer(),
+	brokenEggs: Type.Integer(),
+	collectedBy: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+	notes: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'eggCollection',
+	additionalProperties: false,
+});
+
+export const EggCollectionResponseSchema = Type.Object({
+	...EggCollectionSchema.properties,
+	id: Type.String(),
+	flockId: Type.String(),
+	collectedBy: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	usableEggs: Type.Integer(),
+	layRate: Type.Number(),
+}, {
+	$id: 'eggCollectionResponse',
+	additionalProperties: false,
+});
+
+export const EggCollectionCreateSchema = Type.Object({
+	date: Type.String(),
+	totalEggs: Type.Integer({ minimum: 0 }),
+	brokenEggs: Type.Optional(Type.Integer({ minimum: 0 })),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'eggCollectionCreate',
+	additionalProperties: false,
+});
+
+export const EggCollectionUpdateSchema = Type.Object({
+	totalEggs: Type.Optional(Type.Integer({ minimum: 0 })),
+	brokenEggs: Type.Optional(Type.Integer({ minimum: 0 })),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'eggCollectionUpdate',
+	additionalProperties: false,
+});
+
+const EggCollectionParamsSchema = Type.Object({
+	flockId: Type.String(),
+});
+
+const EggCollectionItemParamsSchema = Type.Object({
+	flockId: Type.String(),
+	id: Type.String(),
+});
+
+const EggCollectionQuerySchema = Type.Object({
+	...PaginationQueryProps,
+}, {
+	$id: 'eggCollectionQuery',
+	additionalProperties: false,
+});
+
+export type EggCollection = Static<typeof EggCollectionSchema>;
+export type EggCollectionResponse = Static<typeof EggCollectionResponseSchema>;
+export type EggCollectionCreate = Static<typeof EggCollectionCreateSchema>;
+export type EggCollectionUpdate = Static<typeof EggCollectionUpdateSchema>;
+export type EggCollectionParams = Static<typeof EggCollectionParamsSchema>;
+export type EggCollectionItemParams = Static<typeof EggCollectionItemParamsSchema>;
+export type EggCollectionQuery = Static<typeof EggCollectionQuerySchema>;
+
+export const listEggCollectionsSchema = createListEndpointSchema({
+	params: EggCollectionParamsSchema,
+	querystring: EggCollectionQuerySchema,
+	dataSchema: Type.Array(EggCollectionResponseSchema),
+	errorCodes: [404],
+});
+
+export const createEggCollectionSchema = createPostEndpointSchema({
+	params: EggCollectionParamsSchema,
+	body: EggCollectionCreateSchema,
+	dataSchema: EggCollectionResponseSchema,
+	errorCodes: [400, 404, 409],
+});
+
+export const updateEggCollectionSchema = createUpdateEndpointSchema({
+	params: EggCollectionItemParamsSchema,
+	body: EggCollectionUpdateSchema,
+	dataSchema: EggCollectionResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const deleteEggCollectionSchema = createDeleteEndpointSchema({
+	params: EggCollectionItemParamsSchema,
+	errorCodes: [404],
+});

--- a/src/resources/egg-collection/egg-collection.serializer.ts
+++ b/src/resources/egg-collection/egg-collection.serializer.ts
@@ -1,0 +1,30 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { EggCollectionResponse } from './egg-collection.schema';
+import { EggCollectionModel } from './egg-collection.model';
+
+export class EggCollectionSerializer {
+	static serialize(collection: EggCollectionModel, currentCount: number): EggCollectionResponse {
+		const usableEggs = collection.totalEggs - collection.brokenEggs;
+		const layRate = currentCount > 0
+			? Number(((collection.totalEggs / currentCount) * 100).toFixed(2))
+			: 0;
+
+		return {
+			id: encodeId(collection.id),
+			flockId: encodeId(collection.flockId),
+			date: collection.date,
+			totalEggs: collection.totalEggs,
+			brokenEggs: collection.brokenEggs,
+			collectedBy: collection.collectedBy ? encodeId(collection.collectedBy) : null,
+			notes: collection.notes,
+			usableEggs,
+			layRate,
+			createdAt: collection.createdAt,
+			updatedAt: collection.updatedAt,
+		};
+	}
+
+	static serializeMany(collections: EggCollectionModel[], currentCount: number): EggCollectionResponse[] {
+		return collections.map(c => this.serialize(c, currentCount));
+	}
+}

--- a/src/resources/egg-collection/egg-collection.service.ts
+++ b/src/resources/egg-collection/egg-collection.service.ts
@@ -1,0 +1,107 @@
+import { BaseService } from '../../services/base.service';
+import { EggCollectionModel } from './egg-collection.model';
+import { EggCollectionCreate, EggCollectionUpdate } from './egg-collection.schema';
+import { FindOptions, Op } from 'sequelize';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+import { FlockStatus } from '../flock/flock.schema';
+
+export class EggCollectionService extends BaseService {
+
+	async getEggCollections(flockId: number, pagination?: PaginationParams): Promise<PaginatedResult<EggCollectionModel>> {
+		const findOptions: FindOptions = {
+			where: { flockId },
+			order: [['date', 'DESC']],
+		};
+
+		return this.findAllPaginated(this.db.models.EggCollection, findOptions, pagination!);
+	}
+
+	async createEggCollection({ flockId, data, userId }: {
+		flockId: number;
+		data: EggCollectionCreate;
+		userId: number;
+	}): Promise<EggCollectionModel> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const flock = await this.db.models.Flock.findByPk(flockId, { transaction });
+
+			if (!flock) {
+				throw new Error('Flock not found');
+			}
+
+			if (flock.status !== FlockStatus.Active) {
+				throw new Error('Cannot add egg collection to an inactive flock.');
+			}
+
+			const brokenEggs = data.brokenEggs ?? 0;
+			if (brokenEggs > data.totalEggs) {
+				throw new Error('Broken eggs cannot exceed total eggs.');
+			}
+
+			// Validate unique date per flock
+			const existing = await this.db.models.EggCollection.findOne({
+				where: { flockId, date: data.date },
+				transaction,
+			});
+
+			if (existing) {
+				throw new Error('An egg collection already exists for this flock on this date.');
+			}
+
+			return this.db.models.EggCollection.create({
+				flockId,
+				date: data.date,
+				totalEggs: data.totalEggs,
+				brokenEggs,
+				collectedBy: userId,
+				notes: data.notes,
+			}, { transaction });
+		});
+	}
+
+	async updateEggCollection({ flockId, collectionId, data }: {
+		flockId: number;
+		collectionId: number;
+		data: EggCollectionUpdate;
+	}): Promise<EggCollectionModel> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const collection = await this.db.models.EggCollection.findOne({
+				where: { id: collectionId, flockId },
+				transaction,
+				lock: true,
+			});
+
+			if (!collection) {
+				throw new Error('Egg collection not found');
+			}
+
+			const totalEggs = data.totalEggs ?? collection.totalEggs;
+			const brokenEggs = data.brokenEggs ?? collection.brokenEggs;
+
+			if (brokenEggs > totalEggs) {
+				throw new Error('Broken eggs cannot exceed total eggs.');
+			}
+
+			await collection.update(data, { transaction });
+
+			return collection;
+		});
+	}
+
+	async deleteEggCollection({ flockId, collectionId }: {
+		flockId: number;
+		collectionId: number;
+	}): Promise<void> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const collection = await this.db.models.EggCollection.findOne({
+				where: { id: collectionId, flockId },
+				transaction,
+			});
+
+			if (!collection) {
+				throw new Error('Egg collection not found');
+			}
+
+			await collection.destroy({ transaction });
+		});
+	}
+}

--- a/src/resources/egg-collection/index.ts
+++ b/src/resources/egg-collection/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import eggCollectionRoutes from './egg-collection.routes';
+
+const eggCollectionPlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(eggCollectionRoutes);
+};
+
+export default eggCollectionPlugin;

--- a/src/resources/flock-event/flock-event.model.ts
+++ b/src/resources/flock-event/flock-event.model.ts
@@ -1,0 +1,86 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { FlockEvent, FlockEventType } from './flock-event.schema';
+
+type FlockEventCreationAttributes = Pick<FlockEvent, 'flockId' | 'eventType' | 'count' | 'date'> & Partial<Pick<FlockEvent, 'reason' | 'recordedBy'>>;
+
+export class FlockEventModel extends Model<FlockEvent, FlockEventCreationAttributes> {
+	declare id: number;
+	declare flockId: number;
+	declare eventType: FlockEventType;
+	declare count: number;
+	declare date: string;
+	declare reason: string | null;
+	declare recordedBy: number | null;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFlockEventModel = (sequelize: Sequelize) => FlockEventModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	flockId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'flock_id',
+		references: { model: 'flocks', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	eventType: {
+		type: DataTypes.ENUM(...Object.values(FlockEventType)),
+		allowNull: false,
+		field: 'event_type',
+	},
+	count: {
+		type: DataTypes.INTEGER,
+		allowNull: false,
+		validate: {
+			min: 1,
+		},
+	},
+	date: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+	},
+	reason: {
+		type: DataTypes.STRING,
+		allowNull: true,
+	},
+	recordedBy: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: true,
+		field: 'recorded_by',
+		references: { model: 'users', key: 'id' },
+		onDelete: 'SET NULL',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'flock_events',
+	modelName: 'FlockEvent',
+	timestamps: true,
+	indexes: [
+		{
+			fields: ['flock_id', 'date'],
+			name: 'idx_flock_events_flock_date',
+		},
+		{
+			fields: ['flock_id', 'event_type'],
+			name: 'idx_flock_events_flock_type',
+		},
+	],
+});

--- a/src/resources/flock-event/flock-event.routes.ts
+++ b/src/resources/flock-event/flock-event.routes.ts
@@ -1,0 +1,59 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import {
+	FlockEventParams,
+	FlockEventDeleteParams,
+	FlockEventCreate,
+	FlockEventQuery,
+	listFlockEventsSchema,
+	createFlockEventSchema,
+	deleteFlockEventSchema,
+} from './flock-event.schema';
+import { decodeId } from '../../utils/id-hash-util';
+import { FlockEventSerializer } from './flock-event.serializer';
+import { parsePagination } from '../../utils/pagination';
+
+const flockEventRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/flocks/:flockId/events', { schema: listFlockEventsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockEventParams, Querystring: FlockEventQuery }>, reply) => {
+		try {
+			const { flockId } = request.params;
+			const pagination = parsePagination(request.query);
+			const result = await fastify.flockEventService.getFlockEvents(decodeId(flockId)!, pagination);
+			const serialized = FlockEventSerializer.serializeMany(result.rows);
+			reply.successWithPagination(serialized, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/flocks/:flockId/events', { schema: createFlockEventSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockEventParams, Body: FlockEventCreate }>, reply) => {
+		try {
+			const { flockId } = request.params;
+			const userId = request.user!.id;
+			const event = await fastify.flockEventService.createFlockEvent({
+				flockId: decodeId(flockId)!,
+				data: request.body,
+				userId,
+			});
+			const serialized = FlockEventSerializer.serialize(event);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/flocks/:flockId/events/:id', { schema: deleteFlockEventSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockEventDeleteParams }>, reply) => {
+		try {
+			const { flockId, id } = request.params;
+			await fastify.flockEventService.deleteFlockEvent({
+				flockId: decodeId(flockId)!,
+				eventId: decodeId(id)!,
+			});
+			reply.success(null);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default flockEventRoutes;

--- a/src/resources/flock-event/flock-event.schema.ts
+++ b/src/resources/flock-event/flock-event.schema.ts
@@ -1,0 +1,92 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+export enum FlockEventType {
+	Mortality = 'mortality',
+	Sale = 'sale',
+	Cull = 'cull',
+	Addition = 'addition',
+	Transfer = 'transfer',
+}
+
+const FlockEventSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	flockId: Type.Integer(),
+	eventType: Type.Enum(FlockEventType),
+	count: Type.Integer(),
+	date: Type.String(),
+	reason: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	recordedBy: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'flockEvent',
+	additionalProperties: false,
+});
+
+export const FlockEventResponseSchema = Type.Object({
+	...FlockEventSchema.properties,
+	id: Type.String(),
+	flockId: Type.String(),
+	recordedBy: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+}, {
+	$id: 'flockEventResponse',
+	additionalProperties: false,
+});
+
+export const FlockEventCreateSchema = Type.Object({
+	eventType: Type.Enum(FlockEventType),
+	count: Type.Integer({ minimum: 1 }),
+	date: Type.String(),
+	reason: Type.Optional(Type.String()),
+}, {
+	$id: 'flockEventCreate',
+	additionalProperties: false,
+});
+
+const FlockEventParamsSchema = Type.Object({
+	flockId: Type.String(),
+});
+
+const FlockEventDeleteParamsSchema = Type.Object({
+	flockId: Type.String(),
+	id: Type.String(),
+});
+
+const FlockEventQuerySchema = Type.Object({
+	...PaginationQueryProps,
+}, {
+	$id: 'flockEventQuery',
+	additionalProperties: false,
+});
+
+export type FlockEvent = Static<typeof FlockEventSchema>;
+export type FlockEventResponse = Static<typeof FlockEventResponseSchema>;
+export type FlockEventCreate = Static<typeof FlockEventCreateSchema>;
+export type FlockEventParams = Static<typeof FlockEventParamsSchema>;
+export type FlockEventDeleteParams = Static<typeof FlockEventDeleteParamsSchema>;
+export type FlockEventQuery = Static<typeof FlockEventQuerySchema>;
+
+export const listFlockEventsSchema = createListEndpointSchema({
+	params: FlockEventParamsSchema,
+	querystring: FlockEventQuerySchema,
+	dataSchema: Type.Array(FlockEventResponseSchema),
+	errorCodes: [404],
+});
+
+export const createFlockEventSchema = createPostEndpointSchema({
+	params: FlockEventParamsSchema,
+	body: FlockEventCreateSchema,
+	dataSchema: FlockEventResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const deleteFlockEventSchema = createDeleteEndpointSchema({
+	params: FlockEventDeleteParamsSchema,
+	errorCodes: [404],
+});

--- a/src/resources/flock-event/flock-event.serializer.ts
+++ b/src/resources/flock-event/flock-event.serializer.ts
@@ -1,0 +1,23 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FlockEventResponse } from './flock-event.schema';
+import { FlockEventModel } from './flock-event.model';
+
+export class FlockEventSerializer {
+	static serialize(event: FlockEventModel): FlockEventResponse {
+		return {
+			id: encodeId(event.id),
+			flockId: encodeId(event.flockId),
+			eventType: event.eventType,
+			count: event.count,
+			date: event.date,
+			reason: event.reason,
+			recordedBy: event.recordedBy ? encodeId(event.recordedBy) : null,
+			createdAt: event.createdAt,
+			updatedAt: event.updatedAt,
+		};
+	}
+
+	static serializeMany(events: FlockEventModel[]): FlockEventResponse[] {
+		return events.map(e => this.serialize(e));
+	}
+}

--- a/src/resources/flock-event/flock-event.service.ts
+++ b/src/resources/flock-event/flock-event.service.ts
@@ -1,0 +1,103 @@
+import { BaseService } from '../../services/base.service';
+import { FlockEventModel } from './flock-event.model';
+import { FlockEventCreate, FlockEventType } from './flock-event.schema';
+import { FindOptions } from 'sequelize';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+
+const SUBTRACTION_EVENTS: FlockEventType[] = [
+	FlockEventType.Mortality,
+	FlockEventType.Sale,
+	FlockEventType.Cull,
+];
+
+export class FlockEventService extends BaseService {
+
+	async getFlockEvents(flockId: number, pagination?: PaginationParams): Promise<PaginatedResult<FlockEventModel>> {
+		const findOptions: FindOptions = {
+			where: { flockId },
+			order: [['date', 'DESC'], ['createdAt', 'DESC']],
+		};
+
+		return this.findAllPaginated(this.db.models.FlockEvent, findOptions, pagination!);
+	}
+
+	async createFlockEvent({ flockId, data, userId }: {
+		flockId: number;
+		data: FlockEventCreate;
+		userId: number;
+	}): Promise<FlockEventModel> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			// Lock the flock row to prevent concurrent count updates
+			const flock = await this.db.models.Flock.findByPk(flockId, {
+				transaction,
+				lock: true,
+			});
+
+			if (!flock) {
+				throw new Error('Flock not found');
+			}
+
+			const isSubtraction = SUBTRACTION_EVENTS.includes(data.eventType);
+
+			if (isSubtraction) {
+				if (data.count > flock.currentCount) {
+					throw new Error(`Cannot remove ${data.count} from flock. Current count is ${flock.currentCount}.`);
+				}
+			}
+
+			// Create the event
+			const event = await this.db.models.FlockEvent.create({
+				flockId,
+				eventType: data.eventType,
+				count: data.count,
+				date: data.date,
+				reason: data.reason,
+				recordedBy: userId,
+			}, { transaction });
+
+			// Update flock current count
+			const countChange = isSubtraction ? -data.count : data.count;
+			await flock.update({
+				currentCount: flock.currentCount + countChange,
+			}, { transaction });
+
+			return event;
+		});
+	}
+
+	async deleteFlockEvent({ flockId, eventId }: {
+		flockId: number;
+		eventId: number;
+	}): Promise<void> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const event = await this.db.models.FlockEvent.findOne({
+				where: { id: eventId, flockId },
+				transaction,
+			});
+
+			if (!event) {
+				throw new Error('Flock event not found');
+			}
+
+			// Lock the flock row
+			const flock = await this.db.models.Flock.findByPk(flockId, {
+				transaction,
+				lock: true,
+			});
+
+			if (!flock) {
+				throw new Error('Flock not found');
+			}
+
+			// Reverse the count change
+			const isSubtraction = SUBTRACTION_EVENTS.includes(event.eventType);
+			const reverseChange = isSubtraction ? event.count : -event.count;
+
+			await flock.update({
+				currentCount: flock.currentCount + reverseChange,
+			}, { transaction });
+
+			await event.destroy({ transaction });
+		});
+	}
+}

--- a/src/resources/flock-event/index.ts
+++ b/src/resources/flock-event/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import flockEventRoutes from './flock-event.routes';
+
+const flockEventPlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(flockEventRoutes);
+};
+
+export default flockEventPlugin;

--- a/src/resources/flock/flock.model.ts
+++ b/src/resources/flock/flock.model.ts
@@ -1,0 +1,141 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { Flock, FlockAcquisitionType, FlockStatus, FlockType } from './flock.schema';
+
+type FlockCreationAttributes = Pick<Flock, 'farmId' | 'speciesId' | 'breedId' | 'name' | 'flockType' | 'initialCount' | 'currentCount' | 'startDate' | 'acquisitionType'> & Partial<Pick<Flock, 'status' | 'endDate' | 'houseName' | 'ageAtAcquisitionWeeks' | 'notes'>>;
+
+export class FlockModel extends Model<Flock, FlockCreationAttributes> {
+	declare id: number;
+	declare farmId: number;
+	declare speciesId: number;
+	declare breedId: number;
+	declare name: string;
+	declare flockType: string;
+	declare initialCount: number;
+	declare currentCount: number;
+	declare status: string;
+	declare startDate: string;
+	declare endDate: string | null;
+	declare houseName: string | null;
+	declare acquisitionType: string;
+	declare ageAtAcquisitionWeeks: number | null;
+	declare notes: string | null;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFlockModel = (sequelize: Sequelize) => FlockModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	farmId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'farm_id',
+		references: { model: 'farms', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	speciesId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'species_id',
+		references: { model: 'species', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	breedId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'breed_id',
+		references: { model: 'breeds', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	name: {
+		type: DataTypes.STRING,
+		allowNull: false,
+		field: 'name',
+	},
+	flockType: {
+		type: DataTypes.ENUM(...Object.values(FlockType)),
+		allowNull: false,
+		field: 'flock_type',
+	},
+	initialCount: {
+		type: DataTypes.INTEGER,
+		allowNull: false,
+		field: 'initial_count',
+	},
+	currentCount: {
+		type: DataTypes.INTEGER,
+		allowNull: false,
+		field: 'current_count',
+	},
+	status: {
+		type: DataTypes.ENUM(...Object.values(FlockStatus)),
+		allowNull: false,
+		field: 'status',
+		defaultValue: FlockStatus.Active,
+	},
+	startDate: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+		field: 'start_date',
+	},
+	endDate: {
+		type: DataTypes.DATEONLY,
+		allowNull: true,
+		field: 'end_date',
+	},
+	houseName: {
+		type: DataTypes.STRING,
+		allowNull: true,
+		field: 'house_name',
+	},
+	acquisitionType: {
+		type: DataTypes.ENUM(...Object.values(FlockAcquisitionType)),
+		allowNull: false,
+		field: 'acquisition_type',
+	},
+	ageAtAcquisitionWeeks: {
+		type: DataTypes.INTEGER,
+		allowNull: true,
+		field: 'age_at_acquisition_weeks',
+	},
+	notes: {
+		type: DataTypes.TEXT,
+		allowNull: true,
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'flocks',
+	modelName: 'Flock',
+	timestamps: true,
+	indexes: [
+		{
+			unique: true,
+			fields: ['farm_id', 'name'],
+			name: 'idx_flocks_farm_name_unique',
+		},
+		{
+			fields: ['farm_id', 'status'],
+			name: 'idx_flocks_farm_status',
+		},
+		{
+			fields: ['farm_id', 'species_id'],
+			name: 'idx_flocks_farm_species',
+		},
+	],
+});

--- a/src/resources/flock/flock.routes.ts
+++ b/src/resources/flock/flock.routes.ts
@@ -1,0 +1,114 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import {
+	FlockCreate,
+	FlockUpdate,
+	FlockInclude,
+	FlockParams,
+	createFlockSchema,
+	listFlockSchema,
+	getFlockByIdSchema,
+	updateFlockSchema,
+	deleteFlockSchema,
+} from './flock.schema';
+import { FlockSerializer } from './flock.serializer';
+import { decodeId } from '../../utils/id-hash-util';
+import { parsePagination } from '../../utils/pagination';
+
+const flockRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/', { schema: listFlockSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Querystring: FlockInclude }>, reply) => {
+		try {
+			const { include, language } = request.query;
+			const farmId = request.lastVisitedFarmId;
+			const filters = fastify.flockService.extractFilterParams(request.query);
+			const pagination = parsePagination(request.query);
+			const result = await fastify.flockService.getFlocks(farmId, language, include, filters, pagination);
+			const serialized = FlockSerializer.serializeMany(result.rows);
+			reply.successWithPagination(serialized, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/:id', { schema: getFlockByIdSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockParams, Querystring: FlockInclude }>, reply) => {
+		try {
+			const { id } = request.params;
+			const { include, language } = request.query;
+			const flockId = decodeId(id);
+
+			if (!flockId) {
+				return reply.error('Invalid flock ID', 400);
+			}
+
+			const flock = await fastify.flockService.getFlockById(flockId, language, include);
+
+			if (!flock) {
+				return reply.error('Flock not found', 404);
+			}
+
+			const serialized = FlockSerializer.serialize(flock);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/', { schema: createFlockSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Body: FlockCreate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const { language } = request.body;
+			const flock = await fastify.flockService.createFlock({ data: { ...request.body, farmId }, language });
+			const serialized = FlockSerializer.serialize(flock!);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.put('/:id', { schema: updateFlockSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockParams; Body: FlockUpdate }>, reply) => {
+		try {
+			const { id } = request.params;
+			const farmId = request.lastVisitedFarmId;
+			const flockId = decodeId(id);
+
+			if (!flockId) {
+				return reply.error('Invalid flock ID', 400);
+			}
+
+			const flock = await fastify.flockService.updateFlock(flockId, farmId, request.body);
+
+			if (!flock) {
+				return reply.error('Flock not found', 404);
+			}
+
+			const serialized = FlockSerializer.serialize(flock);
+			reply.success(serialized);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/:id', { schema: deleteFlockSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FlockParams }>, reply) => {
+		try {
+			const { id } = request.params;
+			const farmId = request.lastVisitedFarmId;
+			const flockId = decodeId(id);
+
+			if (!flockId) {
+				return reply.error('Invalid flock ID', 400);
+			}
+
+			const deleted = await fastify.flockService.deleteFlock(flockId, farmId);
+
+			if (!deleted) {
+				return reply.error('Flock not found', 404);
+			}
+
+			reply.success({ message: 'Flock deleted successfully' });
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default flockRoutes;

--- a/src/resources/flock/flock.schema.ts
+++ b/src/resources/flock/flock.schema.ts
@@ -1,0 +1,163 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createGetEndpointSchema,
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createUpdateEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+import { SpeciesResponseSchema } from '../species/species.schema';
+import { BreedResponseSchema } from '../breed/breed.schema';
+import { UserLanguage } from '../user/user.schema';
+import { FlockModel } from './flock.model';
+import { SpeciesModel } from '../species/species.model';
+import { SpeciesTranslationModel } from '../species-translation/species-translation.model';
+import { BreedModel } from '../breed/breed.model';
+import { BreedTranslationModel } from '../breed-translation/breed-translation.model';
+
+export enum FlockType {
+	Layers = 'layers',
+	Broilers = 'broilers',
+	DualPurpose = 'dual_purpose',
+	General = 'general',
+}
+
+export enum FlockStatus {
+	Active = 'active',
+	Sold = 'sold',
+	Culled = 'culled',
+	Completed = 'completed',
+}
+
+export enum FlockAcquisitionType {
+	Hatched = 'hatched',
+	Purchased = 'purchased',
+	Other = 'other',
+}
+
+export type FlockWithPossibleIncludes = FlockModel & {
+	species?: SpeciesModel & {
+		translations?: SpeciesTranslationModel[];
+	};
+	breed?: BreedModel & {
+		translations?: BreedTranslationModel[];
+	};
+};
+
+const FlockSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	farmId: Type.Integer(),
+	speciesId: Type.Integer(),
+	breedId: Type.Integer(),
+	name: Type.String(),
+	flockType: Type.Enum(FlockType),
+	initialCount: Type.Integer(),
+	currentCount: Type.Integer(),
+	status: Type.Enum(FlockStatus),
+	startDate: Type.String(),
+	endDate: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	houseName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	acquisitionType: Type.Enum(FlockAcquisitionType),
+	ageAtAcquisitionWeeks: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+	notes: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'flock',
+	additionalProperties: false,
+});
+
+export const FlockCreateSchema = Type.Object({
+	name: Type.String({ minLength: 1 }),
+	speciesId: Type.String(),
+	breedId: Type.String(),
+	flockType: Type.Enum(FlockType),
+	initialCount: Type.Integer({ minimum: 1 }),
+	startDate: Type.String(),
+	acquisitionType: Type.Enum(FlockAcquisitionType),
+	endDate: Type.Optional(Type.String()),
+	houseName: Type.Optional(Type.String()),
+	ageAtAcquisitionWeeks: Type.Optional(Type.Integer({ minimum: 0 })),
+	notes: Type.Optional(Type.String()),
+	language: Type.Enum(UserLanguage),
+}, {
+	$id: 'flockCreate',
+	additionalProperties: false,
+});
+
+export const FlockUpdateSchema = Type.Object({
+	name: Type.Optional(Type.String({ minLength: 1 })),
+	flockType: Type.Optional(Type.Enum(FlockType)),
+	status: Type.Optional(Type.Enum(FlockStatus)),
+	endDate: Type.Optional(Type.String()),
+	houseName: Type.Optional(Type.String()),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'flockUpdate',
+	additionalProperties: false,
+});
+
+export const FlockResponseSchema = Type.Object({
+	...FlockSchema.properties,
+	id: Type.String(),
+	farmId: Type.String(),
+	speciesId: Type.String(),
+	breedId: Type.String(),
+	species: Type.Optional(SpeciesResponseSchema),
+	breed: Type.Optional(BreedResponseSchema),
+}, {
+	$id: 'flockResponse',
+	additionalProperties: false,
+});
+
+export const FlockIncludeSchema = Type.Object({
+	include: Type.Optional(Type.String()),
+	language: Type.Enum(UserLanguage),
+	status: Type.Optional(Type.Enum(FlockStatus)),
+	flockType: Type.Optional(Type.Enum(FlockType)),
+	speciesId: Type.Optional(Type.String()),
+	...PaginationQueryProps,
+});
+
+export const FlockParamsSchema = Type.Object({
+	id: Type.String(),
+});
+
+export type Flock = Static<typeof FlockSchema>;
+export type FlockCreate = Static<typeof FlockCreateSchema>;
+export type FlockUpdate = Static<typeof FlockUpdateSchema>;
+export type FlockResponse = Static<typeof FlockResponseSchema>;
+export type FlockInclude = Static<typeof FlockIncludeSchema>;
+export type FlockParams = Static<typeof FlockParamsSchema>;
+
+export const createFlockSchema = createPostEndpointSchema({
+	body: FlockCreateSchema,
+	dataSchema: FlockResponseSchema,
+	errorCodes: [400, 409],
+});
+
+export const listFlockSchema = createListEndpointSchema({
+	querystring: FlockIncludeSchema,
+	dataSchema: Type.Array(FlockResponseSchema),
+	errorCodes: [404],
+});
+
+export const getFlockByIdSchema = createGetEndpointSchema({
+	params: FlockParamsSchema,
+	querystring: FlockIncludeSchema,
+	dataSchema: FlockResponseSchema,
+	errorCodes: [404],
+});
+
+export const updateFlockSchema = createUpdateEndpointSchema({
+	params: FlockParamsSchema,
+	body: FlockUpdateSchema,
+	dataSchema: FlockResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const deleteFlockSchema = createDeleteEndpointSchema({
+	params: FlockParamsSchema,
+	errorCodes: [400, 404],
+});

--- a/src/resources/flock/flock.serializer.ts
+++ b/src/resources/flock/flock.serializer.ts
@@ -1,0 +1,69 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FlockResponse, FlockWithPossibleIncludes } from './flock.schema';
+
+export class FlockSerializer {
+	static serialize(flock: FlockWithPossibleIncludes): FlockResponse {
+		const base: FlockResponse = {
+			id: encodeId(flock.id),
+			farmId: encodeId(flock.farmId),
+			speciesId: encodeId(flock.speciesId),
+			breedId: encodeId(flock.breedId),
+			name: flock.name,
+			flockType: flock.flockType as FlockResponse['flockType'],
+			initialCount: flock.initialCount,
+			currentCount: flock.currentCount,
+			status: flock.status as FlockResponse['status'],
+			startDate: flock.startDate,
+			endDate: flock.endDate,
+			houseName: flock.houseName,
+			acquisitionType: flock.acquisitionType as FlockResponse['acquisitionType'],
+			ageAtAcquisitionWeeks: flock.ageAtAcquisitionWeeks,
+			notes: flock.notes,
+			createdAt: flock.createdAt,
+			updatedAt: flock.updatedAt,
+		};
+
+		if (flock.species) {
+			base.species = {
+				id: encodeId(flock.species.id),
+				createdAt: flock.species.createdAt,
+				updatedAt: flock.species.updatedAt,
+				...(flock.species.translations && {
+					translations: flock.species.translations.map(t => ({
+						id: encodeId(t.id),
+						language: t.language,
+						name: t.name,
+						createdAt: t.createdAt,
+						updatedAt: t.updatedAt,
+						speciesId: encodeId(t.speciesId),
+					})),
+				}),
+			};
+		}
+
+		if (flock.breed) {
+			base.breed = {
+				id: encodeId(flock.breed.id),
+				createdAt: flock.breed.createdAt,
+				updatedAt: flock.breed.updatedAt,
+				speciesId: encodeId(flock.breed.speciesId),
+				...(flock.breed.translations && {
+					translations: flock.breed.translations.map(t => ({
+						id: encodeId(t.id),
+						language: t.language,
+						name: t.name,
+						createdAt: t.createdAt,
+						updatedAt: t.updatedAt,
+						breedId: encodeId(t.breedId),
+					})),
+				}),
+			};
+		}
+
+		return base;
+	}
+
+	static serializeMany(flocks: FlockWithPossibleIncludes[]): FlockResponse[] {
+		return flocks.map(f => this.serialize(f));
+	}
+}

--- a/src/resources/flock/flock.service.ts
+++ b/src/resources/flock/flock.service.ts
@@ -1,0 +1,204 @@
+import { BaseService } from '../../services/base.service';
+import { FlockModel } from './flock.model';
+import { FlockCreate, FlockStatus, FlockType, FlockUpdate } from './flock.schema';
+import { decodeId } from '../../utils/id-hash-util';
+import { IncludeParser, TypedIncludeConfig } from '../../utils/include-parser';
+import { FindOptions, Op } from 'sequelize';
+import { UserLanguage } from '../user/user.schema';
+import { FilterConfig, FilterConfigBuilder } from '../../utils/filter-parser';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+
+export class FlockService extends BaseService {
+
+	private static readonly ALLOWED_INCLUDES = IncludeParser.createConfig({
+		species: {
+			model: 'Species' as const,
+			as: 'species',
+			attributes: ['id', 'createdAt', 'updatedAt'],
+			nested: {
+				translations: {
+					model: 'SpeciesTranslation' as const,
+					as: 'translations',
+					attributes: ['id', 'language', 'name', 'createdAt', 'updatedAt'],
+				},
+			},
+		},
+		breed: {
+			model: 'Breed' as const,
+			as: 'breed',
+			attributes: ['id', 'createdAt', 'updatedAt', 'speciesId'],
+			nested: {
+				translations: {
+					model: 'BreedTranslation' as const,
+					as: 'translations',
+					attributes: ['id', 'breedId', 'language', 'name', 'createdAt', 'updatedAt'],
+				},
+			},
+		},
+	} satisfies TypedIncludeConfig);
+
+	private static readonly ALLOWED_FILTERS: FilterConfig = {
+		status: FilterConfigBuilder.enum('status', Object.values(FlockStatus)),
+		flockType: FilterConfigBuilder.enum('flockType', Object.values(FlockType)),
+		speciesId: {
+			attribute: 'speciesId',
+			operator: 'eq',
+			type: 'number',
+			transform: (value: string) => {
+				const decoded = decodeId(value);
+				if (!decoded) {
+					throw new Error(`Invalid speciesId: ${value}`);
+				}
+				return decoded;
+			},
+		},
+	};
+
+	async getFlocks(farmId: number, language: UserLanguage, includeParam?: string, filters?: Record<string, string>, pagination?: PaginationParams): Promise<PaginatedResult<FlockModel>> {
+		let includes = this.parseIncludes(includeParam, FlockService.ALLOWED_INCLUDES);
+		const filterWhere = this.parseFilters(filters, FlockService.ALLOWED_FILTERS);
+
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
+			includes = this.filterTranslationsByLanguage(includes, language);
+		}
+
+		const findOptions: FindOptions = {
+			where: {
+				farmId,
+				...filterWhere,
+			},
+			include: includes,
+		};
+
+		return this.findAllPaginated(this.db.models.Flock, findOptions, pagination!);
+	}
+
+	async getFlockById(id: number, language: UserLanguage, includeParam?: string): Promise<FlockModel | null> {
+		let includes = this.parseIncludes(includeParam, FlockService.ALLOWED_INCLUDES);
+
+		if (includeParam?.includes('species.translations') || includeParam?.includes('breed.translations')) {
+			includes = this.filterTranslationsByLanguage(includes, language);
+		}
+
+		return this.db.models.Flock.findByPk(id, { include: includes });
+	}
+
+	async createFlock({ data, language }: { data: FlockCreate & { farmId: number }, language: UserLanguage }): Promise<FlockModel | null> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const speciesId = decodeId(data.speciesId);
+			const breedId = decodeId(data.breedId);
+
+			if (!speciesId || !breedId) {
+				throw new Error('Invalid species or breed ID');
+			}
+
+			await this.validateBreedSpeciesMatch(breedId, speciesId, transaction);
+			await this.validateNameUniqueness(data.name, data.farmId, transaction);
+
+			const { language: _language, speciesId: _speciesId, breedId: _breedId, ...rest } = data;
+
+			const flock = await this.db.models.Flock.create({
+				...rest,
+				speciesId,
+				breedId,
+				currentCount: data.initialCount,
+			}, { transaction });
+
+			return this.db.models.Flock.findByPk(flock.id, {
+				include: [
+					{
+						model: this.db.models.Species,
+						as: 'species',
+						attributes: ['id', 'createdAt', 'updatedAt'],
+						include: [
+							{
+								model: this.db.models.SpeciesTranslation,
+								as: 'translations',
+								attributes: ['id', 'language', 'name', 'createdAt', 'updatedAt'],
+								where: { language },
+								required: false,
+							},
+						],
+					},
+					{
+						model: this.db.models.Breed,
+						as: 'breed',
+						attributes: ['id', 'createdAt', 'updatedAt', 'speciesId'],
+						include: [
+							{
+								model: this.db.models.BreedTranslation,
+								as: 'translations',
+								attributes: ['id', 'breedId', 'language', 'name', 'createdAt', 'updatedAt'],
+								where: { language },
+								required: false,
+							},
+						],
+					},
+				],
+				transaction,
+			});
+		});
+	}
+
+	async updateFlock(id: number, farmId: number, data: FlockUpdate): Promise<FlockModel | null> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const flock = await this.db.models.Flock.findOne({
+				where: { id, farmId },
+				transaction,
+				lock: true,
+			});
+
+			if (!flock) {
+				throw new Error('Flock not found');
+			}
+
+			if (data.name && data.name !== flock.name) {
+				await this.validateNameUniqueness(data.name, farmId, transaction, id);
+			}
+
+			await flock.update(data, { transaction });
+
+			return flock;
+		});
+	}
+
+	async deleteFlock(id: number, farmId: number): Promise<boolean> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const flock = await this.db.models.Flock.findOne({
+				where: { id, farmId },
+				transaction,
+			});
+
+			if (!flock) {
+				return false;
+			}
+
+			await flock.destroy({ transaction });
+			return true;
+		});
+	}
+
+	private async validateBreedSpeciesMatch(breedId: number, speciesId: number, transaction: import('sequelize').Transaction): Promise<void> {
+		const breed = await this.db.models.Breed.findByPk(breedId, { transaction });
+		if (!breed) {
+			throw new Error('Breed not found.');
+		}
+		if (breed.speciesId !== speciesId) {
+			throw new Error('Selected breed does not belong to the specified species.');
+		}
+	}
+
+	private async validateNameUniqueness(name: string, farmId: number, transaction: import('sequelize').Transaction, excludeId?: number): Promise<void> {
+		const where: Record<string, unknown> = { name, farmId };
+		if (excludeId) {
+			where.id = { [Op.ne]: excludeId };
+		}
+		const existing = await this.db.models.Flock.findOne({
+			where,
+			transaction,
+		});
+		if (existing) {
+			throw new Error('A flock with this name already exists on this farm.');
+		}
+	}
+}

--- a/src/resources/flock/index.ts
+++ b/src/resources/flock/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import flockRoutes from './flock.routes';
+
+const flockPlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(flockRoutes, { prefix: '/flocks' });
+};
+
+export default flockPlugin;

--- a/src/scripts/dev-seed.js
+++ b/src/scripts/dev-seed.js
@@ -11,6 +11,7 @@
  *   - 15 animals across all species/breeds
  *   - 40+ measurements (weight, height, temperature) per animal
  *   - 15+ expenses across categories
+ *   - 2 chicken flocks with flock events and egg collections
  */
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -270,6 +271,115 @@ async function main() {
 		expenseCount++;
 	}
 	console.log(`Created ${expenseCount} expenses`);
+
+	// --- Flocks (Chicken) ---
+	const chickenSpeciesId = species['Chicken'];
+	const chickenBreeds = {};
+	for (const [key, id] of Object.entries(breeds)) {
+		if (key.startsWith('Chicken:')) {
+			chickenBreeds[key.replace('Chicken:', '')] = id;
+		}
+	}
+
+	const flockDefs = [
+		{
+			name: 'Layer Flock A',
+			breedKey: 'Leghorn',
+			flockType: 'layers',
+			initialCount: 50,
+			currentCount: 47,
+			startDate: '2025-10-01',
+			acquisitionType: 'purchased',
+			houseName: 'Coop 1',
+			ageAtAcquisitionWeeks: 18,
+			notes: 'First batch of laying hens',
+		},
+		{
+			name: 'Dual Purpose Flock B',
+			breedKey: 'Rhode Island Red',
+			flockType: 'dual_purpose',
+			initialCount: 30,
+			currentCount: 28,
+			startDate: '2025-11-15',
+			acquisitionType: 'purchased',
+			houseName: 'Coop 2',
+			ageAtAcquisitionWeeks: 16,
+			notes: 'Mixed use flock for eggs and meat',
+		},
+	];
+
+	const flockIds = [];
+	for (const f of flockDefs) {
+		const flock = await queryOne(
+			`INSERT INTO flocks (farm_id, species_id, breed_id, name, flock_type, initial_count, current_count, status, start_date, acquisition_type, house_name, age_at_acquisition_weeks, notes, created_at, updated_at)
+			 VALUES (:farmId, :speciesId, :breedId, :name, :flockType, :initialCount, :currentCount, 'active', :startDate, :acquisitionType, :houseName, :ageAtAcquisitionWeeks, :notes, :now, :now)
+			 RETURNING id`,
+			{
+				farmId, speciesId: chickenSpeciesId, breedId: chickenBreeds[f.breedKey],
+				name: f.name, flockType: f.flockType, initialCount: f.initialCount,
+				currentCount: f.currentCount, startDate: f.startDate,
+				acquisitionType: f.acquisitionType, houseName: f.houseName,
+				ageAtAcquisitionWeeks: f.ageAtAcquisitionWeeks, notes: f.notes, now,
+			},
+		);
+		flockIds.push({ id: flock.id, ...f });
+	}
+	console.log(`Created ${flockIds.length} flocks`);
+
+	// --- Flock Events ---
+	const flockEventDefs = [
+		// Layer Flock A: 50 initial → -2 mortality → -1 cull = 47 current
+		{ flockIdx: 0, eventType: 'mortality', count: 2, date: '2025-11-10', reason: 'Predator attack' },
+		{ flockIdx: 0, eventType: 'cull', count: 1, date: '2025-12-05', reason: 'Sick hen, not recovering' },
+		// Dual Purpose Flock B: 30 initial → -1 mortality → -1 sale = 28 current
+		{ flockIdx: 1, eventType: 'mortality', count: 1, date: '2025-12-20', reason: 'Unknown cause' },
+		{ flockIdx: 1, eventType: 'sale', count: 1, date: '2026-01-15', reason: 'Rooster sold to neighbor' },
+	];
+
+	for (const e of flockEventDefs) {
+		await query(
+			`INSERT INTO flock_events (flock_id, event_type, count, date, reason, recorded_by, created_at, updated_at)
+			 VALUES (:flockId, :eventType, :count, :date, :reason, :userId, :now, :now)`,
+			{
+				flockId: flockIds[e.flockIdx].id, eventType: e.eventType,
+				count: e.count, date: e.date, reason: e.reason, userId, now,
+			},
+		);
+	}
+	console.log(`Created ${flockEventDefs.length} flock events`);
+
+	// --- Egg Collections ---
+	// Generate 14 days of egg data for each flock
+	const eggCollections = [];
+	for (let daysAgo = 14; daysAgo >= 1; daysAgo--) {
+		const date = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
+			.toISOString().split('T')[0];
+
+		// Layer Flock A: ~85-92% lay rate (47 hens)
+		const flockAEggs = 40 + Math.floor(Math.random() * 4);
+		const flockABroken = Math.random() < 0.3 ? Math.floor(Math.random() * 3) : 0;
+		eggCollections.push({
+			flockId: flockIds[0].id, date, totalEggs: flockAEggs,
+			brokenEggs: flockABroken, notes: null,
+		});
+
+		// Dual Purpose Flock B: ~60-75% lay rate (28 hens)
+		const flockBEggs = 17 + Math.floor(Math.random() * 4);
+		const flockBBroken = Math.random() < 0.2 ? Math.floor(Math.random() * 2) : 0;
+		eggCollections.push({
+			flockId: flockIds[1].id, date, totalEggs: flockBEggs,
+			brokenEggs: flockBBroken, notes: null,
+		});
+	}
+
+	for (const ec of eggCollections) {
+		await query(
+			`INSERT INTO egg_collections (flock_id, date, total_eggs, broken_eggs, collected_by, notes, created_at, updated_at)
+			 VALUES (:flockId, :date, :totalEggs, :brokenEggs, :userId, :notes, :now, :now)`,
+			{ flockId: ec.flockId, date: ec.date, totalEggs: ec.totalEggs, brokenEggs: ec.brokenEggs, userId, notes: ec.notes, now },
+		);
+	}
+	console.log(`Created ${eggCollections.length} egg collections`);
 
 	console.log('\nDev seed complete!');
 	console.log('Login: testuser@test.com / Password1');

--- a/src/seeders/1-species-demo-data-seeder.js
+++ b/src/seeders/1-species-demo-data-seeder.js
@@ -14,12 +14,13 @@ module.exports = {
 			{ created_at: now, updated_at: now },
 			{ created_at: now, updated_at: now },
 			{ created_at: now, updated_at: now },
+			{ created_at: now, updated_at: now },
 		]);
 
 		const [rows] = await queryInterface.sequelize.query(
 			'SELECT id FROM species ORDER BY id ASC;',
 		);
-		const [sheepId, cattleId, goatId, pigId] = rows.map((r) => r.id);
+		const [sheepId, cattleId, goatId, pigId, chickenId] = rows.map((r) => r.id);
 
 		const speciesTranslations = [
 			{ species_id: sheepId, language_code: 'en', name: 'Sheep', created_at: now, updated_at: now },
@@ -30,6 +31,8 @@ module.exports = {
 			{ species_id: goatId, language_code: 'es', name: 'Caprino', created_at: now, updated_at: now },
 			{ species_id: pigId, language_code: 'en', name: 'Pig', created_at: now, updated_at: now },
 			{ species_id: pigId, language_code: 'es', name: 'Porcino', created_at: now, updated_at: now },
+			{ species_id: chickenId, language_code: 'en', name: 'Chicken', created_at: now, updated_at: now },
+			{ species_id: chickenId, language_code: 'es', name: 'Pollo', created_at: now, updated_at: now },
 		];
 		await queryInterface.bulkInsert('species_translation', speciesTranslations);
 	},

--- a/src/seeders/2-breed-demo-data-seeder.js
+++ b/src/seeders/2-breed-demo-data-seeder.js
@@ -28,6 +28,7 @@ module.exports = {
 			{ species: 'Cattle', breeds: [{ en: 'Holstein', es: 'Holstein' }, { en: 'Angus', es: 'Angus' }, { en: 'Other', es: 'Otro' }] },
 			{ species: 'Goat', breeds: [{ en: 'Boer', es: 'Boer' }, { en: 'Saanen', es: 'Saanen' }, { en: 'Other', es: 'Otro' }] },
 			{ species: 'Pig', breeds: [{ en: 'Yorkshire', es: 'Yorkshire' }, { en: 'Duroc', es: 'Duroc' }, { en: 'Other', es: 'Otro' }] },
+			{ species: 'Chicken', breeds: [{ en: 'Leghorn', es: 'Leghorn' }, { en: 'Rhode Island Red', es: 'Rhode Island Red' }, { en: 'Plymouth Rock', es: 'Plymouth Rock' }, { en: 'Other', es: 'Otro' }] },
 		];
 
 		for (const group of breedData) {

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -99,6 +99,48 @@ export async function createMeasurement(
 	};
 }
 
+export async function createFlock(
+	app: FastifyInstance,
+	farmId: number,
+	speciesId: number,
+	breedId: number,
+	overrides?: {
+		name?: string;
+		flockType?: string;
+		initialCount?: number;
+		status?: string;
+		startDate?: string;
+		acquisitionType?: string;
+		endDate?: string;
+		houseName?: string;
+		ageAtAcquisitionWeeks?: number;
+		notes?: string;
+	},
+): Promise<{ flockId: number; encodedFlockId: string }> {
+	const initialCount = overrides?.initialCount ?? 100;
+	const flock = await app.db.models.Flock.create({
+		farmId,
+		speciesId,
+		breedId,
+		name: overrides?.name ?? `Flock-${Date.now()}`,
+		flockType: overrides?.flockType ?? 'general',
+		initialCount,
+		currentCount: initialCount,
+		status: overrides?.status ?? 'active',
+		startDate: overrides?.startDate ?? '2025-01-01',
+		acquisitionType: overrides?.acquisitionType ?? 'purchased',
+		...(overrides?.endDate ? { endDate: overrides.endDate } : {}),
+		...(overrides?.houseName ? { houseName: overrides.houseName } : {}),
+		...(overrides?.ageAtAcquisitionWeeks !== undefined ? { ageAtAcquisitionWeeks: overrides.ageAtAcquisitionWeeks } : {}),
+		...(overrides?.notes ? { notes: overrides.notes } : {}),
+	});
+
+	return {
+		flockId: flock.dataValues.id,
+		encodedFlockId: encodeId(flock.dataValues.id),
+	};
+}
+
 export async function createExpense(
 	app: FastifyInstance,
 	farmId: number,

--- a/tests/integration/flock.test.ts
+++ b/tests/integration/flock.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import { createSpecies, createBreed, createFlock } from '../helpers/factories';
+import { encodeId } from '../../src/utils/id-hash-util';
+
+describe('Flock endpoints', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('GET /api/v1/flocks', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/flocks?language=en',
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('returns flocks with default pagination', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Flock A' });
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Flock B' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/flocks?language=en',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.data).toHaveLength(2);
+			expect(body.meta.pagination).toBeDefined();
+			expect(body.meta.pagination.total).toBe(2);
+		});
+
+		it('returns paginated results with custom page and limit', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Flock 1' });
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Flock 2' });
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Flock 3' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/flocks?language=en&page=1&limit=2',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+			expect(body.meta.pagination.total).toBe(3);
+			expect(body.meta.pagination.totalPages).toBe(2);
+		});
+
+		it('filters flocks by status', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Active Flock', status: 'active' });
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Sold Flock', status: 'sold' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/flocks?language=en&status=active',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].status).toBe('active');
+		});
+
+		it('filters flocks by flockType', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Layer Flock', flockType: 'layers' });
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'General Flock', flockType: 'general' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/flocks?language=en&flockType=layers',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].flockType).toBe('layers');
+		});
+	});
+
+	describe('POST /api/v1/flocks', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				payload: {
+					name: 'Test Flock',
+					speciesId: 'fakeid',
+					breedId: 'fakeid',
+					flockType: 'general',
+					initialCount: 50,
+					startDate: '2025-01-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('creates a new flock with currentCount equal to initialCount', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				headers: { cookie },
+				payload: {
+					name: 'New Flock',
+					speciesId: encodeId(speciesId),
+					breedId: encodeId(breedId),
+					flockType: 'layers',
+					initialCount: 75,
+					startDate: '2025-06-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.data.name).toBe('New Flock');
+			expect(body.data.initialCount).toBe(75);
+			expect(body.data.currentCount).toBe(75);
+			expect(typeof body.data.id).toBe('string');
+		});
+
+		it('returns flock with species and breed includes', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app, { name: 'Chicken' });
+			const { breedId } = await createBreed(app, speciesId, { name: 'Leghorn' });
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				headers: { cookie },
+				payload: {
+					name: 'Include Flock',
+					speciesId: encodeId(speciesId),
+					breedId: encodeId(breedId),
+					flockType: 'general',
+					initialCount: 50,
+					startDate: '2025-01-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.species).toBeDefined();
+			expect(body.data.species.translations).toHaveLength(1);
+			expect(body.data.species.translations[0].name).toBe('Chicken');
+			expect(body.data.breed).toBeDefined();
+			expect(body.data.breed.translations).toHaveLength(1);
+			expect(body.data.breed.translations[0].name).toBe('Leghorn');
+		});
+
+		it('rejects duplicate name on same farm', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+
+			await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				headers: { cookie },
+				payload: {
+					name: 'Duplicate Flock',
+					speciesId: encodeId(speciesId),
+					breedId: encodeId(breedId),
+					flockType: 'general',
+					initialCount: 50,
+					startDate: '2025-01-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				headers: { cookie },
+				payload: {
+					name: 'Duplicate Flock',
+					speciesId: encodeId(speciesId),
+					breedId: encodeId(breedId),
+					flockType: 'general',
+					initialCount: 30,
+					startDate: '2025-02-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			const body = response.json();
+			expect(body.message).toContain('already exists');
+		});
+
+		it('rejects mismatched breed and species', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const { speciesId: species1Id } = await createSpecies(app, { name: 'Chicken' });
+			const { speciesId: species2Id } = await createSpecies(app, { name: 'Duck' });
+			const { breedId } = await createBreed(app, species2Id, { name: 'Pekin' });
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/flocks',
+				headers: { cookie },
+				payload: {
+					name: 'Mismatch Flock',
+					speciesId: encodeId(species1Id),
+					breedId: encodeId(breedId),
+					flockType: 'general',
+					initialCount: 50,
+					startDate: '2025-01-01',
+					acquisitionType: 'purchased',
+					language: 'en',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			const body = response.json();
+			expect(body.message).toContain('does not belong');
+		});
+	});
+
+	describe('GET /api/v1/flocks/:id', () => {
+		it('returns a single flock by id', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId, { name: 'Finder Flock' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/flocks/${encodedFlockId}?language=en`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.name).toBe('Finder Flock');
+		});
+
+		it('returns 404 for non-existent flock', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/flocks/${encodeId(99999)}?language=en`,
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(404);
+		});
+	});
+
+	describe('PUT /api/v1/flocks/:id', () => {
+		it('updates flock fields', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId, { name: 'Old Name' });
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/flocks/${encodedFlockId}`,
+				headers: { cookie },
+				payload: {
+					name: 'New Name',
+					status: 'sold',
+					houseName: 'Barn C',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.name).toBe('New Name');
+			expect(body.data.status).toBe('sold');
+			expect(body.data.houseName).toBe('Barn C');
+		});
+
+		it('rejects duplicate name on update', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			await createFlock(app, user.farmId, speciesId, breedId, { name: 'Taken Name' });
+			const { encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId, { name: 'Other Flock' });
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/flocks/${encodedFlockId}`,
+				headers: { cookie },
+				payload: {
+					name: 'Taken Name',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			const body = response.json();
+			expect(body.message).toContain('already exists');
+		});
+	});
+
+	describe('DELETE /api/v1/flocks/:id', () => {
+		it('deletes a flock', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { speciesId } = await createSpecies(app);
+			const { breedId } = await createBreed(app, speciesId);
+			const { encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId, { name: 'To Delete' });
+
+			const response = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/flocks/${encodedFlockId}`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+		});
+
+		it('returns 404 for non-existent flock', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/flocks/${encodeId(99999)}`,
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(404);
+		});
+	});
+});

--- a/tests/unit/flock-serializer.test.ts
+++ b/tests/unit/flock-serializer.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { FlockSerializer } from '../../src/resources/flock/flock.serializer';
+import { encodeId } from '../../src/utils/id-hash-util';
+import { FlockWithPossibleIncludes } from '../../src/resources/flock/flock.schema';
+
+function makeFlock(overrides?: Partial<FlockWithPossibleIncludes>): FlockWithPossibleIncludes {
+	return {
+		id: 1,
+		farmId: 10,
+		speciesId: 20,
+		breedId: 30,
+		name: 'Test Flock',
+		flockType: 'general',
+		initialCount: 100,
+		currentCount: 100,
+		status: 'active',
+		startDate: '2025-01-01',
+		endDate: null,
+		houseName: null,
+		acquisitionType: 'purchased',
+		ageAtAcquisitionWeeks: null,
+		notes: null,
+		createdAt: '2025-01-01T00:00:00.000Z',
+		updatedAt: '2025-01-01T00:00:00.000Z',
+		...overrides,
+	} as FlockWithPossibleIncludes;
+}
+
+describe('FlockSerializer', () => {
+	describe('serialize', () => {
+		it('encodes all id fields as hashes', () => {
+			const flock = makeFlock({ id: 1, farmId: 10, speciesId: 20, breedId: 30 });
+			const result = FlockSerializer.serialize(flock);
+			expect(result.id).toBe(encodeId(1));
+			expect(result.farmId).toBe(encodeId(10));
+			expect(result.speciesId).toBe(encodeId(20));
+			expect(result.breedId).toBe(encodeId(30));
+		});
+
+		it('includes scalar fields directly', () => {
+			const flock = makeFlock({
+				name: 'Layers A',
+				flockType: 'layers',
+				initialCount: 50,
+				currentCount: 45,
+				status: 'active',
+				startDate: '2025-03-01',
+				acquisitionType: 'hatched',
+			});
+			const result = FlockSerializer.serialize(flock);
+			expect(result.name).toBe('Layers A');
+			expect(result.flockType).toBe('layers');
+			expect(result.initialCount).toBe(50);
+			expect(result.currentCount).toBe(45);
+			expect(result.status).toBe('active');
+			expect(result.startDate).toBe('2025-03-01');
+			expect(result.acquisitionType).toBe('hatched');
+		});
+
+		it('handles nullable fields when null', () => {
+			const flock = makeFlock({
+				endDate: null,
+				houseName: null,
+				ageAtAcquisitionWeeks: null,
+				notes: null,
+			});
+			const result = FlockSerializer.serialize(flock);
+			expect(result.endDate).toBeNull();
+			expect(result.houseName).toBeNull();
+			expect(result.ageAtAcquisitionWeeks).toBeNull();
+			expect(result.notes).toBeNull();
+		});
+
+		it('includes species relation when present', () => {
+			const flock = makeFlock({
+				species: {
+					id: 20,
+					createdAt: '2025-01-01T00:00:00.000Z',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					translations: [
+						{
+							id: 1,
+							speciesId: 20,
+							language: 'en',
+							name: 'Chicken',
+							createdAt: '2025-01-01T00:00:00.000Z',
+							updatedAt: '2025-01-01T00:00:00.000Z',
+						},
+					],
+				} as FlockWithPossibleIncludes['species'],
+			});
+			const result = FlockSerializer.serialize(flock);
+			expect(result.species).toBeDefined();
+			expect(result.species!.id).toBe(encodeId(20));
+			expect(result.species!.translations).toHaveLength(1);
+			expect(result.species!.translations![0].name).toBe('Chicken');
+		});
+
+		it('omits species when not present', () => {
+			const flock = makeFlock();
+			const result = FlockSerializer.serialize(flock);
+			expect(result.species).toBeUndefined();
+		});
+
+		it('includes breed relation when present', () => {
+			const flock = makeFlock({
+				breed: {
+					id: 30,
+					speciesId: 20,
+					createdAt: '2025-01-01T00:00:00.000Z',
+					updatedAt: '2025-01-01T00:00:00.000Z',
+					translations: [
+						{
+							id: 2,
+							breedId: 30,
+							language: 'en',
+							name: 'Leghorn',
+							createdAt: '2025-01-01T00:00:00.000Z',
+							updatedAt: '2025-01-01T00:00:00.000Z',
+						},
+					],
+				} as FlockWithPossibleIncludes['breed'],
+			});
+			const result = FlockSerializer.serialize(flock);
+			expect(result.breed).toBeDefined();
+			expect(result.breed!.id).toBe(encodeId(30));
+			expect(result.breed!.speciesId).toBe(encodeId(20));
+			expect(result.breed!.translations).toHaveLength(1);
+			expect(result.breed!.translations![0].name).toBe('Leghorn');
+		});
+
+		it('omits breed when not present', () => {
+			const flock = makeFlock();
+			const result = FlockSerializer.serialize(flock);
+			expect(result.breed).toBeUndefined();
+		});
+	});
+
+	describe('serializeMany', () => {
+		it('serializes an array of flocks', () => {
+			const flocks = [makeFlock({ id: 1 }), makeFlock({ id: 2 })];
+			const result = FlockSerializer.serializeMany(flocks);
+			expect(result).toHaveLength(2);
+			expect(result[0].id).toBe(encodeId(1));
+			expect(result[1].id).toBe(encodeId(2));
+		});
+	});
+});

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -13,6 +13,9 @@ import { SpeciesService } from '../src/resources/species/species.service';
 import { SpeciesTranslationService } from '../src/resources/species-translation/species-translation.service';
 import { UserService } from '../src/resources/user/user.service';
 import { ExpenseService } from '../src/resources/expense/expense.service';
+import { FlockService } from '../src/resources/flock/flock.service';
+import { FlockEventService } from '../src/resources/flock-event/flock-event.service';
+import { EggCollectionService } from '../src/resources/egg-collection/egg-collection.service';
 
 declare module 'fastify' {
 	interface FastifyInstance {
@@ -33,6 +36,9 @@ declare module 'fastify' {
 		speciesTranslationService: SpeciesTranslationService;
 		userService: UserService;
 		expenseService: ExpenseService;
+		flockService: FlockService;
+		flockEventService: FlockEventService;
+		eggCollectionService: EggCollectionService;
 
 		// Helpers
 		handleDbError: (error: unknown, reply: FastifyReply) => void;


### PR DESCRIPTION
## Summary
- Add full flock management domain: flocks, flock events (mortality/sale/cull/addition/transfer), and egg collections
- Includes 24 passing tests (8 unit + 16 integration) for the flock resource
- Flock-event and egg-collection tests will follow in a separate PR

## Changes

### Flock resource (`/api/v1/flocks`)
- CRUD endpoints with pagination, status/flockType filtering, species & breed includes
- Name uniqueness per farm, breed-species mismatch validation
- `currentCount` auto-set from `initialCount` on create

### Flock events (`/api/v1/flocks/:flockId/events`)
- Track mortality, sales, culls, additions, and transfers
- Auto-updates parent flock's `currentCount` on create/delete

### Egg collections (`/api/v1/flocks/:flockId/egg-collections`)
- Daily egg collection tracking with computed `usableEggs` and `layRate`
- Duplicate date-per-flock prevention
- CRUD with pagination

### Infrastructure
- 3 migrations (flocks, flock_events, egg_collections tables)
- Models, services, serializers, and schemas for all 3 resources
- `createFlock` test factory added

## Frontend integration guide

All endpoints require authentication via `jwt` cookie. All IDs in requests/responses are hashid-encoded strings.

---

### Flocks

#### `GET /api/v1/flocks?language=en`
List flocks for the current farm. Supports pagination (`page`, `limit`) and filtering (`status`, `flockType`, `speciesId`). Optional `include` param for relations (e.g. `include=species.translations,breed.translations`).

**Response:**
```json
{
  "status": "success",
  "data": [
    {
      "id": "Kx8a3p",
      "farmId": "Vm9q2r",
      "speciesId": "Yw4b7n",
      "breedId": "Lp5c1m",
      "name": "Layer Flock A",
      "flockType": "layers",
      "initialCount": 100,
      "currentCount": 95,
      "status": "active",
      "startDate": "2025-01-01",
      "endDate": null,
      "houseName": "Barn C",
      "acquisitionType": "purchased",
      "ageAtAcquisitionWeeks": 20,
      "notes": null,
      "createdAt": "2025-01-01T00:00:00.000Z",
      "updatedAt": "2025-03-20T00:00:00.000Z",
      "species": {
        "id": "Yw4b7n",
        "translations": [{ "id": "Ht2x9k", "language": "en", "name": "Chicken", "speciesId": "Yw4b7n", "createdAt": "...", "updatedAt": "..." }],
        "createdAt": "...",
        "updatedAt": "..."
      },
      "breed": {
        "id": "Lp5c1m",
        "speciesId": "Yw4b7n",
        "translations": [{ "id": "Qr7m4j", "language": "en", "name": "Leghorn", "breedId": "Lp5c1m", "createdAt": "...", "updatedAt": "..." }],
        "createdAt": "...",
        "updatedAt": "..."
      }
    }
  ],
  "meta": {
    "timestamp": "...",
    "pagination": { "page": 1, "limit": 20, "total": 1, "totalPages": 1 }
  }
}
```

#### `POST /api/v1/flocks`
Create a new flock. `currentCount` is automatically set to `initialCount`. Returns the created flock with species/breed includes.

**Request body:**
```json
{
  "name": "Layer Flock A",
  "speciesId": "Yw4b7n",
  "breedId": "Lp5c1m",
  "flockType": "layers | broilers | dual_purpose | general",
  "initialCount": 100,
  "startDate": "2025-01-01",
  "acquisitionType": "hatched | purchased | other",
  "language": "en | es",
  "endDate": "(optional) string",
  "houseName": "(optional) string",
  "ageAtAcquisitionWeeks": "(optional) integer >= 0",
  "notes": "(optional) string"
}
```

**Response:** Same shape as a single item from the GET list, with `species` and `breed` always included.

#### `GET /api/v1/flocks/:id?language=en`
Get a single flock by encoded ID. Supports `include` param.

**Response:** Single flock object (same shape as list items).

**404** if flock does not exist.

#### `PUT /api/v1/flocks/:id`
Update flock fields. All fields optional.

**Request body:**
```json
{
  "name": "(optional) string",
  "flockType": "(optional) layers | broilers | dual_purpose | general",
  "status": "(optional) active | sold | culled | completed",
  "endDate": "(optional) string",
  "houseName": "(optional) string",
  "notes": "(optional) string"
}
```

**Response:** Updated flock object.

**400** if name already taken on the same farm. **404** if flock not found.

#### `DELETE /api/v1/flocks/:id`
Delete a flock.

**Response:**
```json
{ "status": "success", "data": { "message": "Flock deleted successfully" }, "meta": { "timestamp": "..." } }
```

**404** if flock not found.

---

### Flock Events

#### `GET /api/v1/flocks/:flockId/events`
List events for a flock. Supports pagination (`page`, `limit`).

**Response:**
```json
{
  "status": "success",
  "data": [
    {
      "id": "Nw3f8h",
      "flockId": "Kx8a3p",
      "eventType": "mortality",
      "count": 5,
      "date": "2025-03-15",
      "reason": "Disease",
      "recordedBy": "Ab1d2e",
      "createdAt": "...",
      "updatedAt": "..."
    }
  ],
  "meta": { "timestamp": "...", "pagination": { "page": 1, "limit": 20, "total": 1, "totalPages": 1 } }
}
```

#### `POST /api/v1/flocks/:flockId/events`
Record a flock event. Automatically adjusts the flock's `currentCount` (decreases for mortality/sale/cull, increases for addition).

**Request body:**
```json
{
  "eventType": "mortality | sale | cull | addition | transfer",
  "count": 5,
  "date": "2025-03-15",
  "reason": "(optional) string"
}
```

**Response:** Single event object. **400** if count exceeds `currentCount` (for decrease events).

#### `DELETE /api/v1/flocks/:flockId/events/:id`
Delete an event and reverse its effect on `currentCount`.

**Response:**
```json
{ "status": "success", "data": { "message": "Event deleted successfully" }, "meta": { "timestamp": "..." } }
```

---

### Egg Collections

#### `GET /api/v1/flocks/:flockId/egg-collections`
List egg collections for a flock. Supports pagination.

**Response:**
```json
{
  "status": "success",
  "data": [
    {
      "id": "Rz6g1w",
      "flockId": "Kx8a3p",
      "date": "2025-03-20",
      "totalEggs": 85,
      "brokenEggs": 3,
      "usableEggs": 82,
      "layRate": 89.47,
      "collectedBy": "Ab1d2e",
      "notes": null,
      "createdAt": "...",
      "updatedAt": "..."
    }
  ],
  "meta": { "timestamp": "...", "pagination": { "page": 1, "limit": 20, "total": 1, "totalPages": 1 } }
}
```

`usableEggs` = `totalEggs - brokenEggs`. `layRate` = `(totalEggs / flock.currentCount) * 100`.

#### `POST /api/v1/flocks/:flockId/egg-collections`
Record a daily egg collection. One collection per flock per date.

**Request body:**
```json
{
  "date": "2025-03-20",
  "totalEggs": 85,
  "brokenEggs": "(optional, default 0) integer >= 0",
  "notes": "(optional) string"
}
```

**Response:** Single egg collection object. **409** if a collection already exists for that date.

#### `PUT /api/v1/flocks/:flockId/egg-collections/:id`
Update an egg collection.

**Request body:**
```json
{
  "totalEggs": "(optional) integer >= 0",
  "brokenEggs": "(optional) integer >= 0",
  "notes": "(optional) string"
}
```

**Response:** Updated egg collection object.

#### `DELETE /api/v1/flocks/:flockId/egg-collections/:id`
Delete an egg collection.

**Response:**
```json
{ "status": "success", "data": { "message": "Egg collection deleted successfully" }, "meta": { "timestamp": "..." } }
```

## Test plan
- [x] `npx vitest run tests/unit/flock-serializer.test.ts` — 8 unit tests pass
- [x] `npx vitest run tests/integration/flock.test.ts` — 16 integration tests pass
- [ ] Flock-event and egg-collection endpoint tests (follow-up PR)