### PR TITLE
fix(db): replace stale expense refs with financial-transaction

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -18,7 +18,10 @@ import {
 	AnimalMeasurementModel,
 	initAnimalMeasurementModel,
 } from '../resources/animal-measurement/animal-measurement.model';
-import { ExpenseModel, initExpenseModel } from '../resources/expense/expense.model';
+import {
+	FinancialTransactionModel,
+	initFinancialTransactionModel,
+} from '../resources/financial-transaction/financial-transaction.model';
 import { FlockModel, initFlockModel } from '../resources/flock/flock.model';
 import { FlockEventModel, initFlockEventModel } from '../resources/flock-event/flock-event.model';
 import {
@@ -39,7 +42,7 @@ export interface Database {
 		BreedTranslation: typeof BreedTranslationModel;
 		Animal: typeof AnimalModel;
 		AnimalMeasurement: typeof AnimalMeasurementModel;
-		Expense: typeof ExpenseModel;
+		FinancialTransaction: typeof FinancialTransactionModel;
 		Flock: typeof FlockModel;
 		FlockEvent: typeof FlockEventModel;
 		EggCollection: typeof EggCollectionModel;
@@ -83,7 +86,7 @@ export const initDatabase = async (): Promise<Database> => {
 	const BreedTranslation = initBreedTranslationModel(sequelize);
 	const Animal = initAnimalModel(sequelize);
 	const AnimalMeasurement = initAnimalMeasurementModel(sequelize);
-	const Expense = initExpenseModel(sequelize);
+	const FinancialTransaction = initFinancialTransactionModel(sequelize);
 	const Flock = initFlockModel(sequelize);
 	const FlockEvent = initFlockEventModel(sequelize);
 	const EggCollection = initEggCollectionModel(sequelize);
@@ -157,7 +160,7 @@ export const initDatabase = async (): Promise<Database> => {
 			BreedTranslation,
 			Animal,
 			AnimalMeasurement,
-			Expense,
+			FinancialTransaction,
 			Flock,
 			FlockEvent,
 			EggCollection,

--- a/src/resources/financial-transaction/financial-transaction.routes.ts
+++ b/src/resources/financial-transaction/financial-transaction.routes.ts
@@ -85,7 +85,7 @@ const financialTransactionRoutes: FastifyPluginAsync = async (fastify: FastifyIn
 			});
 
 			const serialized = FinancialTransactionSerializer.serialize(transaction);
-			reply.success(serialized);
+			reply.created(serialized);
 		} catch (error) {
 			fastify.handleDbError(error, reply);
 		}

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -141,7 +141,7 @@ export async function createFlock(
 	};
 }
 
-export async function createExpense(
+export async function createFinancialTransaction(
 	app: FastifyInstance,
 	farmId: number,
 	speciesId: number,

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -12,7 +12,7 @@ import { InvitationService } from '../src/resources/invitation/invitation.servic
 import { SpeciesService } from '../src/resources/species/species.service';
 import { SpeciesTranslationService } from '../src/resources/species-translation/species-translation.service';
 import { UserService } from '../src/resources/user/user.service';
-import { ExpenseService } from '../src/resources/expense/expense.service';
+import { FinancialTransactionService } from '../src/resources/financial-transaction/financial-transaction.service';
 import { FlockService } from '../src/resources/flock/flock.service';
 import { FlockEventService } from '../src/resources/flock-event/flock-event.service';
 import { EggCollectionService } from '../src/resources/egg-collection/egg-collection.service';
@@ -35,7 +35,7 @@ declare module 'fastify' {
 		speciesService: SpeciesService;
 		speciesTranslationService: SpeciesTranslationService;
 		userService: UserService;
-		expenseService: ExpenseService;
+		financialTransactionService: FinancialTransactionService;
 		flockService: FlockService;
 		flockEventService: FlockEventService;
 		eggCollectionService: EggCollectionService;


### PR DESCRIPTION
## Summary
- The expense-to-financial-transaction migration left stale imports and type declarations referencing the deleted `expense` module, causing TypeScript compilation errors
- Also fixes the POST route returning 200 instead of 201 and renames the test factory to match

## Changes
- **Database init** (`src/database/index.ts`): replaced `ExpenseModel` import/init/interface with `FinancialTransactionModel`
- **Type declarations** (`types/fastify.d.ts`): replaced `ExpenseService` with `FinancialTransactionService` on `FastifyInstance`
- **POST route**: changed `reply.success()` to `reply.created()` for correct 201 status
- **Test factory**: renamed `createExpense` to `createFinancialTransaction`

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [x] All 165 tests pass across 18 test files
- [ ] App starts without crash (`docker compose up`)