### PR TITLE
feat(weather): add weather endpoint with Open-Meteo integration

### DIFF
--- a/src/plugins/services.plugin.ts
+++ b/src/plugins/services.plugin.ts
@@ -17,6 +17,7 @@ import { UserService } from '../resources/user/user.service';
 import { FlockService } from '../resources/flock/flock.service';
 import { FlockEventService } from '../resources/flock-event/flock-event.service';
 import { EggCollectionService } from '../resources/egg-collection/egg-collection.service';
+import { WeatherService } from '../resources/weather/weather.service';
 
 const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	// Register all services as Fastify decorators
@@ -37,6 +38,7 @@ const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	fastify.decorate('flockService', new FlockService(fastify.db));
 	fastify.decorate('flockEventService', new FlockEventService(fastify.db));
 	fastify.decorate('eggCollectionService', new EggCollectionService(fastify.db));
+	fastify.decorate('weatherService', new WeatherService());
 
 	fastify.log.info('Services plugin registered successfully');
 };

--- a/src/resources/weather/index.ts
+++ b/src/resources/weather/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import weatherRoutes from './weather.routes';
+
+const weatherPlugin: FastifyPluginAsync = async (fastify) => {
+	fastify.register(weatherRoutes, { prefix: '/weather' });
+};
+
+export default weatherPlugin;

--- a/src/resources/weather/weather.routes.ts
+++ b/src/resources/weather/weather.routes.ts
@@ -1,0 +1,20 @@
+import { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import { getWeatherSchema, WeatherQuery } from './weather.schema';
+
+const weatherRoutes: FastifyPluginAsync = async (fastify) => {
+	fastify.get('/', {
+		schema: getWeatherSchema,
+		preHandler: fastify.authenticate,
+	}, async (request: FastifyRequest<{ Querystring: WeatherQuery }>, reply) => {
+		try {
+			const { latitude, longitude } = request.query;
+			const weather = await fastify.weatherService.getWeather(latitude, longitude);
+			reply.success(weather, 'Weather data retrieved successfully');
+		} catch (error) {
+			fastify.log.error(error, 'Failed to fetch weather data from Open-Meteo');
+			reply.error('Weather data unavailable', 502);
+		}
+	});
+};
+
+export default weatherRoutes;

--- a/src/resources/weather/weather.schema.ts
+++ b/src/resources/weather/weather.schema.ts
@@ -1,0 +1,70 @@
+import { Static, Type } from '@sinclair/typebox';
+import { createGetEndpointSchema } from '../../utils/schema-builder';
+
+// ── Request ─────────────────────────────────────────────────────────
+
+export const WeatherQuerySchema = Type.Object({
+	latitude: Type.Number({ minimum: -90, maximum: 90 }),
+	longitude: Type.Number({ minimum: -180, maximum: 180 }),
+}, { $id: 'weatherQuery', additionalProperties: false });
+
+export type WeatherQuery = Static<typeof WeatherQuerySchema>;
+
+// ── Response: Current Weather ───────────────────────────────────────
+
+const CurrentWeatherSchema = Type.Object({
+	temperature: Type.Number(),
+	apparentTemperature: Type.Number(),
+	weatherCode: Type.Integer(),
+	weatherDescription: Type.String(),
+	windSpeed: Type.Number(),
+	humidity: Type.Number(),
+	precipitation: Type.Number(),
+});
+
+// ── Response: Daily Forecast ────────────────────────────────────────
+
+const DailyForecastSchema = Type.Object({
+	date: Type.String(),
+	temperatureMax: Type.Number(),
+	temperatureMin: Type.Number(),
+	precipitationSum: Type.Number(),
+	precipitationProbabilityMax: Type.Integer(),
+	windSpeedMax: Type.Number(),
+	weatherCode: Type.Integer(),
+	weatherDescription: Type.String(),
+	sunrise: Type.String(),
+	sunset: Type.String(),
+	uvIndexMax: Type.Number(),
+});
+
+// ── Response: Full Weather ──────────────────────────────────────────
+
+const WeatherLocationSchema = Type.Object({
+	latitude: Type.Number(),
+	longitude: Type.Number(),
+});
+
+const WeatherUnitsSchema = Type.Object({
+	temperature: Type.String(),
+	windSpeed: Type.String(),
+	precipitation: Type.String(),
+	humidity: Type.String(),
+});
+
+export const WeatherResponseSchema = Type.Object({
+	current: CurrentWeatherSchema,
+	daily: Type.Array(DailyForecastSchema),
+	location: WeatherLocationSchema,
+	units: WeatherUnitsSchema,
+}, { $id: 'weatherResponse', additionalProperties: false });
+
+export type WeatherResponse = Static<typeof WeatherResponseSchema>;
+
+// ── Route Schema ────────────────────────────────────────────────────
+
+export const getWeatherSchema = createGetEndpointSchema({
+	querystring: WeatherQuerySchema,
+	dataSchema: WeatherResponseSchema,
+	errorCodes: [400],
+});

--- a/src/resources/weather/weather.service.ts
+++ b/src/resources/weather/weather.service.ts
@@ -1,0 +1,160 @@
+import { WeatherResponse } from './weather.schema';
+
+// ── Open-Meteo Raw Response Types ───────────────────────────────────
+
+interface OpenMeteoCurrentResponse {
+	temperature_2m: number;
+	apparent_temperature: number;
+	weather_code: number;
+	wind_speed_10m: number;
+	relative_humidity_2m: number;
+	precipitation: number;
+}
+
+interface OpenMeteoDailyResponse {
+	time: string[];
+	temperature_2m_max: number[];
+	temperature_2m_min: number[];
+	precipitation_sum: number[];
+	precipitation_probability_max: number[];
+	wind_speed_10m_max: number[];
+	weather_code: number[];
+	sunrise: string[];
+	sunset: string[];
+	uv_index_max: number[];
+}
+
+interface OpenMeteoResponse {
+	latitude: number;
+	longitude: number;
+	current: OpenMeteoCurrentResponse;
+	current_units: Record<string, string>;
+	daily: OpenMeteoDailyResponse;
+	daily_units: Record<string, string>;
+	error?: boolean;
+	reason?: string;
+}
+
+// ── WMO Weather Code Descriptions ──────────────────────────────────
+
+const WMO_CODES: Record<number, string> = {
+	0: 'Clear sky',
+	1: 'Mainly clear',
+	2: 'Partly cloudy',
+	3: 'Overcast',
+	45: 'Fog',
+	48: 'Depositing rime fog',
+	51: 'Light drizzle',
+	53: 'Moderate drizzle',
+	55: 'Dense drizzle',
+	56: 'Light freezing drizzle',
+	57: 'Dense freezing drizzle',
+	61: 'Slight rain',
+	63: 'Moderate rain',
+	65: 'Heavy rain',
+	66: 'Light freezing rain',
+	67: 'Heavy freezing rain',
+	71: 'Slight snowfall',
+	73: 'Moderate snowfall',
+	75: 'Heavy snowfall',
+	77: 'Snow grains',
+	80: 'Slight rain showers',
+	81: 'Moderate rain showers',
+	82: 'Violent rain showers',
+	85: 'Slight snow showers',
+	86: 'Heavy snow showers',
+	95: 'Thunderstorm',
+	96: 'Thunderstorm with slight hail',
+	99: 'Thunderstorm with heavy hail',
+};
+
+// ── Weather Service ─────────────────────────────────────────────────
+
+const OPEN_METEO_BASE_URL = 'https://api.open-meteo.com/v1/forecast';
+const CURRENT_PARAMS = 'temperature_2m,apparent_temperature,weather_code,wind_speed_10m,relative_humidity_2m,precipitation';
+const DAILY_PARAMS = 'temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,wind_speed_10m_max,weather_code,sunrise,sunset,uv_index_max';
+const TIMEOUT_MS = 10_000;
+
+export class WeatherService {
+	async getWeather(latitude: number, longitude: number): Promise<WeatherResponse> {
+		const url = this.buildUrl(latitude, longitude);
+		const raw = await this.fetchWeatherData(url);
+		return this.transformResponse(raw);
+	}
+
+	private buildUrl(latitude: number, longitude: number): string {
+		const params = new URLSearchParams({
+			latitude: String(latitude),
+			longitude: String(longitude),
+			current: CURRENT_PARAMS,
+			daily: DAILY_PARAMS,
+			timezone: 'auto',
+			forecast_days: '7',
+		});
+
+		return `${OPEN_METEO_BASE_URL}?${params.toString()}`;
+	}
+
+	private async fetchWeatherData(url: string): Promise<OpenMeteoResponse> {
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(TIMEOUT_MS),
+		});
+
+		if (!response.ok) {
+			const body = await response.json().catch(() => null) as { reason?: string } | null;
+			const reason = body?.reason ?? `HTTP ${response.status}`;
+			throw new Error(`Open-Meteo API error: ${reason}`);
+		}
+
+		const data = await response.json() as OpenMeteoResponse;
+
+		if (data.error) {
+			throw new Error(`Open-Meteo API error: ${data.reason ?? 'Unknown error'}`);
+		}
+
+		return data;
+	}
+
+	private transformResponse(raw: OpenMeteoResponse): WeatherResponse {
+		const { current, daily } = raw;
+
+		return {
+			current: {
+				temperature: current.temperature_2m,
+				apparentTemperature: current.apparent_temperature,
+				weatherCode: current.weather_code,
+				weatherDescription: this.getWeatherDescription(current.weather_code),
+				windSpeed: current.wind_speed_10m,
+				humidity: current.relative_humidity_2m,
+				precipitation: current.precipitation,
+			},
+			daily: daily.time.map((date, i) => ({
+				date,
+				temperatureMax: daily.temperature_2m_max[i],
+				temperatureMin: daily.temperature_2m_min[i],
+				precipitationSum: daily.precipitation_sum[i],
+				precipitationProbabilityMax: daily.precipitation_probability_max[i],
+				windSpeedMax: daily.wind_speed_10m_max[i],
+				weatherCode: daily.weather_code[i],
+				weatherDescription: this.getWeatherDescription(daily.weather_code[i]),
+				sunrise: daily.sunrise[i],
+				sunset: daily.sunset[i],
+				uvIndexMax: daily.uv_index_max[i],
+			})),
+			location: {
+				latitude: raw.latitude,
+				longitude: raw.longitude,
+			},
+			units: {
+				temperature: raw.current_units.temperature_2m ?? '°C',
+				windSpeed: raw.current_units.wind_speed_10m ?? 'km/h',
+				precipitation: raw.current_units.precipitation ?? 'mm',
+				humidity: raw.current_units.relative_humidity_2m ?? '%',
+			},
+		};
+	}
+
+	private getWeatherDescription(code: number): string {
+		return WMO_CODES[code] ?? 'Unknown';
+	}
+}

--- a/tests/integration/weather.test.ts
+++ b/tests/integration/weather.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+
+function createOpenMeteoResponse() {
+	return {
+		latitude: -34.625,
+		longitude: -58.5,
+		current: {
+			temperature_2m: 22.5,
+			apparent_temperature: 24.4,
+			weather_code: 0,
+			wind_speed_10m: 4,
+			relative_humidity_2m: 66,
+			precipitation: 0,
+		},
+		current_units: {
+			temperature_2m: '°C',
+			wind_speed_10m: 'km/h',
+			precipitation: 'mm',
+			relative_humidity_2m: '%',
+		},
+		daily: {
+			time: ['2026-03-26'],
+			temperature_2m_max: [26.8],
+			temperature_2m_min: [12.4],
+			precipitation_sum: [0],
+			precipitation_probability_max: [0],
+			wind_speed_10m_max: [11.2],
+			weather_code: [2],
+			sunrise: ['2026-03-26T07:02'],
+			sunset: ['2026-03-26T18:57'],
+			uv_index_max: [6.65],
+		},
+	};
+}
+
+describe('Weather endpoints', () => {
+	let app: FastifyInstance;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('GET /api/v1/weather', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('returns 400 when latitude is missing', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?longitude=-58.4',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('returns 400 when longitude is missing', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('returns 400 when latitude is out of range', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=999&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('returns 400 when longitude is out of range', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=999',
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('returns weather data for valid coordinates', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const mockData = createOpenMeteoResponse();
+			fetchSpy = vi.spyOn(globalThis, 'fetch');
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.status).toBe('success');
+			expect(body.message).toBe('Weather data retrieved successfully');
+			expect(body.data.current).toBeDefined();
+			expect(body.data.daily).toBeDefined();
+			expect(body.data.location).toBeDefined();
+			expect(body.data.units).toBeDefined();
+		});
+
+		it('returns current weather with correct fields', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const mockData = createOpenMeteoResponse();
+			fetchSpy = vi.spyOn(globalThis, 'fetch');
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			const { current } = response.json().data;
+			expect(current.temperature).toBe(22.5);
+			expect(current.apparentTemperature).toBe(24.4);
+			expect(current.weatherCode).toBe(0);
+			expect(current.weatherDescription).toBe('Clear sky');
+			expect(current.windSpeed).toBe(4);
+			expect(current.humidity).toBe(66);
+			expect(current.precipitation).toBe(0);
+		});
+
+		it('returns daily forecast array with correct fields', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			const mockData = createOpenMeteoResponse();
+			fetchSpy = vi.spyOn(globalThis, 'fetch');
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			const { daily } = response.json().data;
+			expect(daily).toHaveLength(1);
+			expect(daily[0].date).toBe('2026-03-26');
+			expect(daily[0].temperatureMax).toBe(26.8);
+			expect(daily[0].temperatureMin).toBe(12.4);
+			expect(daily[0].sunrise).toBe('2026-03-26T07:02');
+			expect(daily[0].sunset).toBe('2026-03-26T18:57');
+			expect(daily[0].uvIndexMax).toBe(6.65);
+		});
+
+		it('returns 502 when Open-Meteo API is unreachable', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			fetchSpy = vi.spyOn(globalThis, 'fetch');
+			fetchSpy.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(502);
+			expect(body.status).toBe('error');
+			expect(body.message).toBe('Weather data unavailable');
+		});
+
+		it('returns 502 when Open-Meteo returns an error status', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+			fetchSpy = vi.spyOn(globalThis, 'fetch');
+			fetchSpy.mockResolvedValueOnce(new Response(
+				JSON.stringify({ reason: 'Bad request' }),
+				{ status: 400 },
+			));
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/weather?latitude=-34.6&longitude=-58.4',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(502);
+			expect(body.status).toBe('error');
+			expect(body.message).toBe('Weather data unavailable');
+		});
+	});
+});

--- a/tests/unit/weather-service.test.ts
+++ b/tests/unit/weather-service.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WeatherService } from '../../src/resources/weather/weather.service';
+
+// ── Open-Meteo mock response factory ────────────────────────────────
+
+function createOpenMeteoResponse(overrides?: Partial<OpenMeteoMock>): OpenMeteoMock {
+	return {
+		latitude: -34.625,
+		longitude: -58.5,
+		current: {
+			temperature_2m: 22.5,
+			apparent_temperature: 24.4,
+			weather_code: 0,
+			wind_speed_10m: 4,
+			relative_humidity_2m: 66,
+			precipitation: 0,
+		},
+		current_units: {
+			temperature_2m: '°C',
+			wind_speed_10m: 'km/h',
+			precipitation: 'mm',
+			relative_humidity_2m: '%',
+		},
+		daily: {
+			time: ['2026-03-26', '2026-03-27'],
+			temperature_2m_max: [26.8, 27.5],
+			temperature_2m_min: [12.4, 18.2],
+			precipitation_sum: [0, 2.5],
+			precipitation_probability_max: [0, 43],
+			wind_speed_10m_max: [11.2, 10.2],
+			weather_code: [2, 61],
+			sunrise: ['2026-03-26T07:02', '2026-03-27T07:02'],
+			sunset: ['2026-03-26T18:57', '2026-03-27T18:55'],
+			uv_index_max: [6.65, 5.9],
+		},
+		...overrides,
+	};
+}
+
+interface OpenMeteoMock {
+	latitude: number;
+	longitude: number;
+	error?: boolean;
+	reason?: string;
+	current: {
+		temperature_2m: number;
+		apparent_temperature: number;
+		weather_code: number;
+		wind_speed_10m: number;
+		relative_humidity_2m: number;
+		precipitation: number;
+	};
+	current_units: Record<string, string>;
+	daily: {
+		time: string[];
+		temperature_2m_max: number[];
+		temperature_2m_min: number[];
+		precipitation_sum: number[];
+		precipitation_probability_max: number[];
+		wind_speed_10m_max: number[];
+		weather_code: number[];
+		sunrise: string[];
+		sunset: string[];
+		uv_index_max: number[];
+	};
+}
+
+describe('WeatherService', () => {
+	let service: WeatherService;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		service = new WeatherService();
+		fetchSpy = vi.spyOn(globalThis, 'fetch');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('getWeather', () => {
+		it('returns transformed current weather and daily forecast', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.current.temperature).toBe(22.5);
+			expect(result.current.apparentTemperature).toBe(24.4);
+			expect(result.current.weatherCode).toBe(0);
+			expect(result.current.weatherDescription).toBe('Clear sky');
+			expect(result.current.windSpeed).toBe(4);
+			expect(result.current.humidity).toBe(66);
+			expect(result.current.precipitation).toBe(0);
+		});
+
+		it('returns correct number of daily forecasts', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.daily).toHaveLength(2);
+		});
+
+		it('transforms daily forecast fields from snake_case to camelCase', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+			const firstDay = result.daily[0];
+
+			expect(firstDay.date).toBe('2026-03-26');
+			expect(firstDay.temperatureMax).toBe(26.8);
+			expect(firstDay.temperatureMin).toBe(12.4);
+			expect(firstDay.precipitationSum).toBe(0);
+			expect(firstDay.precipitationProbabilityMax).toBe(0);
+			expect(firstDay.windSpeedMax).toBe(11.2);
+			expect(firstDay.sunrise).toBe('2026-03-26T07:02');
+			expect(firstDay.sunset).toBe('2026-03-26T18:57');
+			expect(firstDay.uvIndexMax).toBe(6.65);
+		});
+
+		it('maps WMO weather codes to descriptions', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.daily[0].weatherDescription).toBe('Partly cloudy');
+			expect(result.daily[1].weatherDescription).toBe('Slight rain');
+		});
+
+		it('returns "Unknown" for unrecognized WMO codes', async () => {
+			const mockData = createOpenMeteoResponse();
+			mockData.current.weather_code = 999;
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.current.weatherDescription).toBe('Unknown');
+		});
+
+		it('returns location echoing Open-Meteo resolved coordinates', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.location.latitude).toBe(-34.625);
+			expect(result.location.longitude).toBe(-58.5);
+		});
+
+		it('returns measurement units from Open-Meteo response', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			const result = await service.getWeather(-34.6, -58.4);
+
+			expect(result.units).toEqual({
+				temperature: '°C',
+				windSpeed: 'km/h',
+				precipitation: 'mm',
+				humidity: '%',
+			});
+		});
+
+		it('calls Open-Meteo with correct URL parameters', async () => {
+			const mockData = createOpenMeteoResponse();
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(mockData), { status: 200 }));
+
+			await service.getWeather(-34.6, -58.4);
+
+			expect(fetchSpy).toHaveBeenCalledOnce();
+			const calledUrl = fetchSpy.mock.calls[0][0] as string;
+			expect(calledUrl).toContain('latitude=-34.6');
+			expect(calledUrl).toContain('longitude=-58.4');
+			expect(calledUrl).toContain('timezone=auto');
+			expect(calledUrl).toContain('forecast_days=7');
+			expect(calledUrl).toContain('current=');
+			expect(calledUrl).toContain('daily=');
+		});
+
+		it('throws when Open-Meteo returns non-ok HTTP status', async () => {
+			fetchSpy.mockResolvedValueOnce(new Response(
+				JSON.stringify({ reason: 'Invalid parameter' }),
+				{ status: 400 },
+			));
+
+			await expect(service.getWeather(-34.6, -58.4))
+				.rejects.toThrow('Open-Meteo API error: Invalid parameter');
+		});
+
+		it('throws when Open-Meteo returns error in response body', async () => {
+			const errorResponse = {
+				error: true,
+				reason: 'Cannot initialize WeatherVariable from invalid String value',
+			};
+			fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(errorResponse), { status: 200 }));
+
+			await expect(service.getWeather(-34.6, -58.4))
+				.rejects.toThrow('Open-Meteo API error: Cannot initialize WeatherVariable from invalid String value');
+		});
+
+		it('throws when fetch fails due to network error', async () => {
+			fetchSpy.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+			await expect(service.getWeather(-34.6, -58.4))
+				.rejects.toThrow('fetch failed');
+		});
+	});
+});

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -16,6 +16,7 @@ import { FinancialTransactionService } from '../src/resources/financial-transact
 import { FlockService } from '../src/resources/flock/flock.service';
 import { FlockEventService } from '../src/resources/flock-event/flock-event.service';
 import { EggCollectionService } from '../src/resources/egg-collection/egg-collection.service';
+import { WeatherService } from '../src/resources/weather/weather.service';
 
 declare module 'fastify' {
 	interface FastifyInstance {
@@ -39,6 +40,7 @@ declare module 'fastify' {
 		flockService: FlockService;
 		flockEventService: FlockEventService;
 		eggCollectionService: EggCollectionService;
+		weatherService: WeatherService;
 
 		// Helpers
 		handleDbError: (error: unknown, reply: FastifyReply) => void;


### PR DESCRIPTION
## Summary
- Integrate Open-Meteo free weather API so users can see current conditions and a 7-day forecast for their farm location
- First external API integration in the codebase — no API key required, no database changes needed

## Changes
### Weather resource (`src/resources/weather/`)
- **weather.schema.ts** — TypeBox schemas for query validation (lat/lon with bounds) and response (current + daily forecast)
- **weather.service.ts** — Standalone service (no BaseService/DB) calling Open-Meteo with native `fetch`, 10s timeout, WMO weather code descriptions
- **weather.routes.ts** — Single `GET /` route with auth guard
- **index.ts** — Plugin entry, auto-loaded at `/api/v1/weather`

### Registration
- **services.plugin.ts** — Register `WeatherService` as Fastify decorator
- **types/fastify.d.ts** — Add `weatherService` type augmentation

### Tests
- **Unit tests** (11) — Service transformation, WMO code mapping, URL construction, error handling
- **Integration tests** (10) — Auth guard, query validation, response structure, upstream failure handling

---

## API Reference (for frontend)

### `GET /api/v1/weather?latitude={lat}&longitude={lon}`

**Auth:** Requires JWT cookie

**Query params:**
| Param | Type | Required | Constraints |
|-------|------|----------|-------------|
| `latitude` | number | yes | -90 to 90 |
| `longitude` | number | yes | -180 to 180 |

**Example request:**
```
GET /api/v1/weather?latitude=-34.6&longitude=-58.4
Cookie: jwt=<token>
```

**Success response (200):**
```json
{
  "status": "success",
  "message": "Weather data retrieved successfully",
  "data": {
    "current": {
      "temperature": 22.5,
      "apparentTemperature": 24.4,
      "weatherCode": 0,
      "weatherDescription": "Clear sky",
      "windSpeed": 4,
      "humidity": 66,
      "precipitation": 0
    },
    "daily": [
      {
        "date": "2026-03-26",
        "temperatureMax": 26.8,
        "temperatureMin": 12.4,
        "precipitationSum": 0,
        "precipitationProbabilityMax": 0,
        "windSpeedMax": 11.2,
        "weatherCode": 2,
        "weatherDescription": "Partly cloudy",
        "sunrise": "2026-03-26T07:02",
        "sunset": "2026-03-26T18:57",
        "uvIndexMax": 6.65
      }
    ],
    "location": {
      "latitude": -34.625,
      "longitude": -58.5
    },
    "units": {
      "temperature": "°C",
      "windSpeed": "km/h",
      "precipitation": "mm",
      "humidity": "%"
    }
  },
  "meta": {
    "timestamp": "2026-03-26T13:39:40.542Z"
  }
}
```

**Error responses:**
| Status | When |
|--------|------|
| 400 | Missing or invalid lat/lon (out of range) |
| 401 | Not authenticated |
| 502 | Open-Meteo API unavailable or errored |

---

## Test plan
- [x] `GET /api/v1/weather?latitude=-34.6&longitude=-58.4` with auth → 200 with current + 7-day forecast
- [x] Without auth cookie → 401
- [x] Invalid coords (`latitude=999`) → 400
- [x] Missing query params → 400
- [x] 11 unit tests passing
- [x] 10 integration tests passing