### PR TITLE
feat(feed-inventory): FIFO feed lot, type, and consumption tracking (Phase 1/3)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -28,6 +28,13 @@ import {
 	EggCollectionModel,
 	initEggCollectionModel,
 } from '../resources/egg-collection/egg-collection.model';
+import { FeedTypeModel, initFeedTypeModel } from '../resources/feed-type/feed-type.model';
+import { FeedLotModel, initFeedLotModel } from '../resources/feed-lot/feed-lot.model';
+import { FeedConsumptionModel, initFeedConsumptionModel } from '../resources/feed-consumption/feed-consumption.model';
+import {
+	FeedConsumptionLotModel,
+	initFeedConsumptionLotModel,
+} from '../resources/feed-consumption/feed-consumption-lot.model';
 
 export interface Database {
 	sequelize: Sequelize;
@@ -46,6 +53,10 @@ export interface Database {
 		Flock: typeof FlockModel;
 		FlockEvent: typeof FlockEventModel;
 		EggCollection: typeof EggCollectionModel;
+		FeedType: typeof FeedTypeModel;
+		FeedLot: typeof FeedLotModel;
+		FeedConsumption: typeof FeedConsumptionModel;
+		FeedConsumptionLot: typeof FeedConsumptionLotModel;
 	};
 }
 
@@ -90,6 +101,10 @@ export const initDatabase = async (): Promise<Database> => {
 	const Flock = initFlockModel(sequelize);
 	const FlockEvent = initFlockEventModel(sequelize);
 	const EggCollection = initEggCollectionModel(sequelize);
+	const FeedType = initFeedTypeModel(sequelize);
+	const FeedLot = initFeedLotModel(sequelize);
+	const FeedConsumption = initFeedConsumptionModel(sequelize);
+	const FeedConsumptionLot = initFeedConsumptionLotModel(sequelize);
 
 	// associations
 	// Farm & FarmMembers
@@ -147,6 +162,28 @@ export const initDatabase = async (): Promise<Database> => {
 	EggCollection.belongsTo(UserModel, { foreignKey: 'collectedBy', as: 'collector' });
 	Flock.hasMany(EggCollection, { foreignKey: 'flockId', as: 'eggCollections' });
 
+	// Feed inventory associations
+	FeedType.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
+	FarmModel.hasMany(FeedType, { foreignKey: 'farmId', as: 'feedTypes' });
+
+	FeedLot.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
+	FeedLot.belongsTo(FeedType, { foreignKey: 'feedTypeId', as: 'feedType' });
+	FeedLot.belongsTo(UserModel, { foreignKey: 'createdBy', as: 'creator' });
+	FeedType.hasMany(FeedLot, { foreignKey: 'feedTypeId', as: 'lots' });
+	FarmModel.hasMany(FeedLot, { foreignKey: 'farmId', as: 'feedLots' });
+
+	FeedConsumption.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
+	FeedConsumption.belongsTo(Flock, { foreignKey: 'flockId', as: 'flock' });
+	FeedConsumption.belongsTo(FeedType, { foreignKey: 'feedTypeId', as: 'feedType' });
+	FeedConsumption.belongsTo(UserModel, { foreignKey: 'createdBy', as: 'creator' });
+	FeedConsumption.hasMany(FeedConsumptionLot, { foreignKey: 'consumptionId', as: 'lots' });
+	Flock.hasMany(FeedConsumption, { foreignKey: 'flockId', as: 'feedConsumptions' });
+	FeedType.hasMany(FeedConsumption, { foreignKey: 'feedTypeId', as: 'consumptions' });
+
+	FeedConsumptionLot.belongsTo(FeedConsumption, { foreignKey: 'consumptionId', as: 'consumption' });
+	FeedConsumptionLot.belongsTo(FeedLot, { foreignKey: 'lotId', as: 'lot' });
+	FeedLot.hasMany(FeedConsumptionLot, { foreignKey: 'lotId', as: 'consumptionLots' });
+
 	const db: Database = {
 		sequelize,
 		models: {
@@ -164,6 +201,10 @@ export const initDatabase = async (): Promise<Database> => {
 			Flock,
 			FlockEvent,
 			EggCollection,
+			FeedType,
+			FeedLot,
+			FeedConsumption,
+			FeedConsumptionLot,
 		},
 	};
 

--- a/src/migrations/20260414120000-create-feed-types-table.js
+++ b/src/migrations/20260414120000-create-feed-types-table.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('feed_types', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			farm_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'farms', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			name: {
+				type: Sequelize.STRING(120),
+				allowNull: false,
+			},
+			notes: {
+				type: Sequelize.TEXT,
+				allowNull: true,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.addIndex('feed_types', ['farm_id', 'name'], {
+			unique: true,
+			name: 'idx_feed_types_farm_name_unique',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('feed_types', 'idx_feed_types_farm_name_unique');
+		await queryInterface.dropTable('feed_types');
+	},
+};

--- a/src/migrations/20260414120001-create-feed-lots-table.js
+++ b/src/migrations/20260414120001-create-feed-lots-table.js
@@ -1,0 +1,92 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('feed_lots', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			farm_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'farms', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			feed_type_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'feed_types', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			qty_purchased: {
+				type: Sequelize.DECIMAL(12, 3),
+				allowNull: false,
+			},
+			qty_remaining: {
+				type: Sequelize.DECIMAL(12, 3),
+				allowNull: false,
+			},
+			unit_price: {
+				type: Sequelize.DECIMAL(12, 2),
+				allowNull: false,
+			},
+			purchased_at: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			supplier: {
+				type: Sequelize.STRING(255),
+				allowNull: true,
+			},
+			notes: {
+				type: Sequelize.TEXT,
+				allowNull: true,
+			},
+			created_by: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'users', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feed_lots ADD CONSTRAINT chk_feed_lots_qty_purchased_positive CHECK (qty_purchased > 0)',
+		);
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feed_lots ADD CONSTRAINT chk_feed_lots_qty_remaining_bounds CHECK (qty_remaining >= 0 AND qty_remaining <= qty_purchased)',
+		);
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feed_lots ADD CONSTRAINT chk_feed_lots_unit_price_non_negative CHECK (unit_price >= 0)',
+		);
+
+		await queryInterface.addIndex('feed_lots', ['farm_id', 'feed_type_id', 'purchased_at', 'id'], {
+			name: 'idx_feed_lots_fifo_drain',
+		});
+		await queryInterface.sequelize.query(
+			'CREATE INDEX idx_feed_lots_available ON feed_lots (farm_id, feed_type_id) WHERE qty_remaining > 0',
+		);
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_feed_lots_available');
+		await queryInterface.removeIndex('feed_lots', 'idx_feed_lots_fifo_drain');
+		await queryInterface.dropTable('feed_lots');
+	},
+};

--- a/src/migrations/20260414120002-create-feed-consumptions-table.js
+++ b/src/migrations/20260414120002-create-feed-consumptions-table.js
@@ -1,0 +1,89 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('feed_consumptions', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			farm_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'farms', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			flock_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: true,
+				references: { model: 'flocks', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			feed_type_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'feed_types', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			consumed_at: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			qty: {
+				type: Sequelize.DECIMAL(12, 3),
+				allowNull: false,
+			},
+			reason: {
+				type: Sequelize.ENUM('feeding', 'waste', 'transfer', 'adjustment'),
+				allowNull: false,
+			},
+			notes: {
+				type: Sequelize.TEXT,
+				allowNull: true,
+			},
+			created_by: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'users', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feed_consumptions ADD CONSTRAINT chk_feed_consumptions_qty_positive CHECK (qty > 0)',
+		);
+		await queryInterface.sequelize.query(
+			"ALTER TABLE feed_consumptions ADD CONSTRAINT chk_feed_consumptions_flock_required CHECK (flock_id IS NOT NULL OR reason IN ('waste', 'adjustment'))",
+		);
+
+		await queryInterface.addIndex('feed_consumptions', ['farm_id', 'flock_id', 'consumed_at'], {
+			name: 'idx_feed_consumptions_farm_flock_date',
+		});
+		await queryInterface.addIndex('feed_consumptions', ['farm_id', 'feed_type_id', 'consumed_at'], {
+			name: 'idx_feed_consumptions_farm_type_date',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('feed_consumptions', 'idx_feed_consumptions_farm_flock_date');
+		await queryInterface.removeIndex('feed_consumptions', 'idx_feed_consumptions_farm_type_date');
+		await queryInterface.dropTable('feed_consumptions');
+		await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_feed_consumptions_reason"');
+	},
+};

--- a/src/migrations/20260414120003-create-feed-consumption-lots-table.js
+++ b/src/migrations/20260414120003-create-feed-consumption-lots-table.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('feed_consumption_lots', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			consumption_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'feed_consumptions', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			lot_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'feed_lots', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			qty_drawn: {
+				type: Sequelize.DECIMAL(12, 3),
+				allowNull: false,
+			},
+			unit_price_snapshot: {
+				type: Sequelize.DECIMAL(12, 2),
+				allowNull: false,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feed_consumption_lots ADD CONSTRAINT chk_feed_consumption_lots_qty_drawn_positive CHECK (qty_drawn > 0)',
+		);
+
+		await queryInterface.addIndex('feed_consumption_lots', ['consumption_id'], {
+			name: 'idx_feed_consumption_lots_consumption',
+		});
+		await queryInterface.addIndex('feed_consumption_lots', ['lot_id'], {
+			name: 'idx_feed_consumption_lots_lot',
+		});
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeIndex('feed_consumption_lots', 'idx_feed_consumption_lots_consumption');
+		await queryInterface.removeIndex('feed_consumption_lots', 'idx_feed_consumption_lots_lot');
+		await queryInterface.dropTable('feed_consumption_lots');
+	},
+};

--- a/src/plugins/services.plugin.ts
+++ b/src/plugins/services.plugin.ts
@@ -18,6 +18,9 @@ import { FlockService } from '../resources/flock/flock.service';
 import { FlockEventService } from '../resources/flock-event/flock-event.service';
 import { EggCollectionService } from '../resources/egg-collection/egg-collection.service';
 import { WeatherService } from '../resources/weather/weather.service';
+import { FeedTypeService } from '../resources/feed-type/feed-type.service';
+import { FeedLotService } from '../resources/feed-lot/feed-lot.service';
+import { FeedConsumptionService } from '../resources/feed-consumption/feed-consumption.service';
 
 const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	// Register all services as Fastify decorators
@@ -39,6 +42,9 @@ const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	fastify.decorate('flockEventService', new FlockEventService(fastify.db));
 	fastify.decorate('eggCollectionService', new EggCollectionService(fastify.db));
 	fastify.decorate('weatherService', new WeatherService());
+	fastify.decorate('feedTypeService', new FeedTypeService(fastify.db));
+	fastify.decorate('feedLotService', new FeedLotService(fastify.db));
+	fastify.decorate('feedConsumptionService', new FeedConsumptionService(fastify.db));
 
 	fastify.log.info('Services plugin registered successfully');
 };

--- a/src/resources/feed-consumption/feed-consumption-fifo.ts
+++ b/src/resources/feed-consumption/feed-consumption-fifo.ts
@@ -1,0 +1,85 @@
+import { Op, Transaction } from 'sequelize';
+import { Database } from '../../database';
+
+export class InsufficientStockError extends Error {
+	constructor(public readonly requested: number, public readonly available: number) {
+		super(`Insufficient stock: requested ${requested}, available ${available}`);
+		this.name = 'InsufficientStockError';
+	}
+}
+
+export interface DrainableLot {
+	id: number;
+	qtyRemaining: number;
+	unitPrice: number;
+}
+
+export interface LotDraw {
+	lotId: number;
+	qtyDrawn: number;
+	unitPriceSnapshot: number;
+}
+
+const DECIMAL_PLACES = 3;
+
+function round(value: number): number {
+	const factor = 10 ** DECIMAL_PLACES;
+	return Math.round(value * factor) / factor;
+}
+
+export function computeDraws(lots: DrainableLot[], requestedQty: number): LotDraw[] {
+	const draws: LotDraw[] = [];
+	let remaining = round(requestedQty);
+
+	for (const lot of lots) {
+		if (remaining <= 0) break;
+		const draw = round(Math.min(lot.qtyRemaining, remaining));
+		if (draw <= 0) continue;
+		draws.push({ lotId: lot.id, qtyDrawn: draw, unitPriceSnapshot: lot.unitPrice });
+		remaining = round(remaining - draw);
+	}
+
+	if (remaining > 0) {
+		const available = round(lots.reduce((sum, l) => sum + l.qtyRemaining, 0));
+		throw new InsufficientStockError(requestedQty, available);
+	}
+
+	return draws;
+}
+
+export async function drainFIFO(
+	db: Database,
+	params: { farmId: number; feedTypeId: number; qty: number },
+	transaction: Transaction,
+): Promise<LotDraw[]> {
+	const lots = await db.models.FeedLot.findAll({
+		where: {
+			farmId: params.farmId,
+			feedTypeId: params.feedTypeId,
+			qtyRemaining: { [Op.gt]: 0 },
+		},
+		// Consistent lock order (purchasedAt ASC, id ASC) prevents deadlocks
+		// between concurrent consumptions on the same feed_type.
+		order: [['purchasedAt', 'ASC'], ['id', 'ASC']],
+		transaction,
+		lock: transaction.LOCK.UPDATE,
+	});
+
+	const drainableLots: DrainableLot[] = lots.map(lot => ({
+		id: lot.id,
+		qtyRemaining: Number(lot.qtyRemaining),
+		unitPrice: Number(lot.unitPrice),
+	}));
+
+	const draws = computeDraws(drainableLots, params.qty);
+
+	for (const draw of draws) {
+		await db.models.FeedLot.decrement('qtyRemaining', {
+			by: draw.qtyDrawn,
+			where: { id: draw.lotId },
+			transaction,
+		});
+	}
+
+	return draws;
+}

--- a/src/resources/feed-consumption/feed-consumption-lot.model.ts
+++ b/src/resources/feed-consumption/feed-consumption-lot.model.ts
@@ -1,0 +1,68 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+export interface FeedConsumptionLotAttributes {
+	id: number;
+	consumptionId: number;
+	lotId: number;
+	qtyDrawn: number;
+	unitPriceSnapshot: number;
+	createdAt: string;
+}
+
+type FeedConsumptionLotCreationAttributes = Pick<
+	FeedConsumptionLotAttributes,
+	'consumptionId' | 'lotId' | 'qtyDrawn' | 'unitPriceSnapshot'
+>;
+
+export class FeedConsumptionLotModel extends Model<FeedConsumptionLotAttributes, FeedConsumptionLotCreationAttributes> {
+	declare id: number;
+	declare consumptionId: number;
+	declare lotId: number;
+	declare qtyDrawn: number;
+	declare unitPriceSnapshot: number;
+	declare createdAt: string;
+}
+
+export const initFeedConsumptionLotModel = (sequelize: Sequelize) => FeedConsumptionLotModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	consumptionId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'consumption_id',
+		references: { model: 'feed_consumptions', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	lotId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'lot_id',
+		references: { model: 'feed_lots', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	qtyDrawn: {
+		type: DataTypes.DECIMAL(12, 3),
+		allowNull: false,
+		field: 'qty_drawn',
+	},
+	unitPriceSnapshot: {
+		type: DataTypes.DECIMAL(12, 2),
+		allowNull: false,
+		field: 'unit_price_snapshot',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+}, {
+	sequelize,
+	tableName: 'feed_consumption_lots',
+	modelName: 'FeedConsumptionLot',
+	timestamps: false,
+});

--- a/src/resources/feed-consumption/feed-consumption.model.ts
+++ b/src/resources/feed-consumption/feed-consumption.model.ts
@@ -1,0 +1,106 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { FeedConsumptionReason } from './feed-consumption.schema';
+
+export interface FeedConsumptionAttributes {
+	id: number;
+	farmId: number;
+	flockId: number | null;
+	feedTypeId: number;
+	consumedAt: string;
+	qty: number;
+	reason: FeedConsumptionReason;
+	notes: string | null;
+	createdBy: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+type FeedConsumptionCreationAttributes = Pick<
+	FeedConsumptionAttributes,
+	'farmId' | 'feedTypeId' | 'consumedAt' | 'qty' | 'reason' | 'createdBy'
+> & Partial<Pick<FeedConsumptionAttributes, 'flockId' | 'notes'>>;
+
+export class FeedConsumptionModel extends Model<FeedConsumptionAttributes, FeedConsumptionCreationAttributes> {
+	declare id: number;
+	declare farmId: number;
+	declare flockId: number | null;
+	declare feedTypeId: number;
+	declare consumedAt: string;
+	declare qty: number;
+	declare reason: FeedConsumptionReason;
+	declare notes: string | null;
+	declare createdBy: number;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFeedConsumptionModel = (sequelize: Sequelize) => FeedConsumptionModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	farmId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'farm_id',
+		references: { model: 'farms', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	flockId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: true,
+		field: 'flock_id',
+		references: { model: 'flocks', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	feedTypeId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'feed_type_id',
+		references: { model: 'feed_types', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	consumedAt: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+		field: 'consumed_at',
+	},
+	qty: {
+		type: DataTypes.DECIMAL(12, 3),
+		allowNull: false,
+	},
+	reason: {
+		type: DataTypes.ENUM(...Object.values(FeedConsumptionReason)),
+		allowNull: false,
+	},
+	notes: {
+		type: DataTypes.TEXT,
+		allowNull: true,
+	},
+	createdBy: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'created_by',
+		references: { model: 'users', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'feed_consumptions',
+	modelName: 'FeedConsumption',
+	timestamps: true,
+});

--- a/src/resources/feed-consumption/feed-consumption.routes.ts
+++ b/src/resources/feed-consumption/feed-consumption.routes.ts
@@ -1,0 +1,99 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import {
+	FeedConsumptionCreate,
+	FeedConsumptionQuery,
+	FeedConsumptionParams,
+	listFeedConsumptionsSchema,
+	getFeedConsumptionByIdSchema,
+	createFeedConsumptionSchema,
+	deleteFeedConsumptionSchema,
+} from './feed-consumption.schema';
+import { FeedConsumptionSerializer } from './feed-consumption.serializer';
+import { FeedConsumptionFilters, FeedConsumptionWithLots } from './feed-consumption.service';
+import { decodeId } from '../../utils/id-hash-util';
+import { parsePagination } from '../../utils/pagination';
+
+const feedConsumptionRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/', { schema: listFeedConsumptionsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Querystring: FeedConsumptionQuery }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const pagination = parsePagination(request.query);
+
+			const filters: FeedConsumptionFilters = {};
+			if (request.query.flockId) {
+				const decoded = decodeId(request.query.flockId);
+				if (!decoded) return reply.error('Invalid flock ID', 400);
+				filters.flockId = decoded;
+			}
+			if (request.query.feedTypeId) {
+				const decoded = decodeId(request.query.feedTypeId);
+				if (!decoded) return reply.error('Invalid feed type ID', 400);
+				filters.feedTypeId = decoded;
+			}
+			if (request.query.from) filters.from = request.query.from;
+			if (request.query.to) filters.to = request.query.to;
+
+			const includeLots = request.query.include?.includes('lots') ?? false;
+			const result = await fastify.feedConsumptionService.getFeedConsumptions(farmId, filters, includeLots, pagination);
+			const serialized = FeedConsumptionSerializer.serializeMany(result.rows as FeedConsumptionWithLots[]);
+			reply.successWithPagination(serialized, result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/:id', { schema: getFeedConsumptionByIdSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedConsumptionParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const consumptionId = decodeId(request.params.id);
+			if (!consumptionId) {
+				return reply.error('Invalid consumption ID', 400);
+			}
+
+			const consumption = await fastify.feedConsumptionService.getFeedConsumptionById(consumptionId, farmId);
+			if (!consumption) {
+				return reply.error('Feed consumption not found', 404);
+			}
+
+			reply.success(FeedConsumptionSerializer.serialize(consumption as FeedConsumptionWithLots));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/', { schema: createFeedConsumptionSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Body: FeedConsumptionCreate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const userId = request.user!.id;
+			const consumption = await fastify.feedConsumptionService.createFeedConsumption(farmId, userId, request.body);
+			reply.success(FeedConsumptionSerializer.serialize(consumption as FeedConsumptionWithLots));
+		} catch (error) {
+			if (error instanceof Error && error.name === 'InsufficientStockError') {
+				return reply.error(error.message, 422);
+			}
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/:id', { schema: deleteFeedConsumptionSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedConsumptionParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const consumptionId = decodeId(request.params.id);
+			if (!consumptionId) {
+				return reply.error('Invalid consumption ID', 400);
+			}
+
+			const deleted = await fastify.feedConsumptionService.deleteFeedConsumption(consumptionId, farmId);
+			if (!deleted) {
+				return reply.error('Feed consumption not found', 404);
+			}
+
+			reply.success(null, 'Feed consumption deleted successfully');
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default feedConsumptionRoutes;

--- a/src/resources/feed-consumption/feed-consumption.schema.ts
+++ b/src/resources/feed-consumption/feed-consumption.schema.ts
@@ -1,0 +1,100 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createGetEndpointSchema,
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+export enum FeedConsumptionReason {
+	Feeding = 'feeding',
+	Waste = 'waste',
+	Transfer = 'transfer',
+	Adjustment = 'adjustment',
+}
+
+const FeedConsumptionLotResponseSchema = Type.Object({
+	id: Type.String(),
+	lotId: Type.String(),
+	qtyDrawn: Type.Number(),
+	unitPriceSnapshot: Type.Number(),
+}, {
+	$id: 'feedConsumptionLotResponse',
+	additionalProperties: false,
+});
+
+export const FeedConsumptionResponseSchema = Type.Object({
+	id: Type.String(),
+	farmId: Type.String(),
+	flockId: Type.Union([Type.String(), Type.Null()]),
+	feedTypeId: Type.String(),
+	consumedAt: Type.String(),
+	qty: Type.Number(),
+	reason: Type.Enum(FeedConsumptionReason),
+	notes: Type.Union([Type.String(), Type.Null()]),
+	createdBy: Type.String(),
+	totalCost: Type.Number(),
+	lots: Type.Optional(Type.Array(FeedConsumptionLotResponseSchema)),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'feedConsumptionResponse',
+	additionalProperties: false,
+});
+
+export const FeedConsumptionCreateSchema = Type.Object({
+	flockId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	feedTypeId: Type.String(),
+	consumedAt: Type.String({ format: 'date' }),
+	qty: Type.Number({ exclusiveMinimum: 0 }),
+	reason: Type.Enum(FeedConsumptionReason),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'feedConsumptionCreate',
+	additionalProperties: false,
+});
+
+export const FeedConsumptionQuerySchema = Type.Object({
+	flockId: Type.Optional(Type.String()),
+	feedTypeId: Type.Optional(Type.String()),
+	from: Type.Optional(Type.String({ format: 'date' })),
+	to: Type.Optional(Type.String({ format: 'date' })),
+	include: Type.Optional(Type.String()),
+	...PaginationQueryProps,
+}, {
+	$id: 'feedConsumptionQuery',
+	additionalProperties: false,
+});
+
+export const FeedConsumptionParamsSchema = Type.Object({
+	id: Type.String(),
+});
+
+export type FeedConsumptionResponse = Static<typeof FeedConsumptionResponseSchema>;
+export type FeedConsumptionCreate = Static<typeof FeedConsumptionCreateSchema>;
+export type FeedConsumptionQuery = Static<typeof FeedConsumptionQuerySchema>;
+export type FeedConsumptionParams = Static<typeof FeedConsumptionParamsSchema>;
+
+export const listFeedConsumptionsSchema = createListEndpointSchema({
+	querystring: FeedConsumptionQuerySchema,
+	dataSchema: Type.Array(FeedConsumptionResponseSchema),
+	errorCodes: [400],
+});
+
+export const getFeedConsumptionByIdSchema = createGetEndpointSchema({
+	params: FeedConsumptionParamsSchema,
+	dataSchema: FeedConsumptionResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const createFeedConsumptionSchema = createPostEndpointSchema({
+	body: FeedConsumptionCreateSchema,
+	dataSchema: FeedConsumptionResponseSchema,
+	errorCodes: [400, 404, 422],
+});
+
+export const deleteFeedConsumptionSchema = createDeleteEndpointSchema({
+	params: FeedConsumptionParamsSchema,
+	errorCodes: [400, 404],
+});

--- a/src/resources/feed-consumption/feed-consumption.serializer.ts
+++ b/src/resources/feed-consumption/feed-consumption.serializer.ts
@@ -1,0 +1,38 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FeedConsumptionResponse } from './feed-consumption.schema';
+import { FeedConsumptionWithLots } from './feed-consumption.service';
+
+export class FeedConsumptionSerializer {
+	static serialize(consumption: FeedConsumptionWithLots): FeedConsumptionResponse {
+		const lots = consumption.lots ?? [];
+		const totalCost = lots.reduce(
+			(sum, lot) => sum + Number(lot.qtyDrawn) * Number(lot.unitPriceSnapshot),
+			0,
+		);
+
+		return {
+			id: encodeId(consumption.id),
+			farmId: encodeId(consumption.farmId),
+			flockId: consumption.flockId !== null ? encodeId(consumption.flockId) : null,
+			feedTypeId: encodeId(consumption.feedTypeId),
+			consumedAt: consumption.consumedAt,
+			qty: Number(consumption.qty),
+			reason: consumption.reason,
+			notes: consumption.notes,
+			createdBy: encodeId(consumption.createdBy),
+			totalCost: Number(totalCost.toFixed(2)),
+			lots: lots.map(lot => ({
+				id: encodeId(lot.id),
+				lotId: encodeId(lot.lotId),
+				qtyDrawn: Number(lot.qtyDrawn),
+				unitPriceSnapshot: Number(lot.unitPriceSnapshot),
+			})),
+			createdAt: consumption.createdAt,
+			updatedAt: consumption.updatedAt,
+		};
+	}
+
+	static serializeMany(consumptions: FeedConsumptionWithLots[]): FeedConsumptionResponse[] {
+		return consumptions.map(c => this.serialize(c));
+	}
+}

--- a/src/resources/feed-consumption/feed-consumption.service.ts
+++ b/src/resources/feed-consumption/feed-consumption.service.ts
@@ -1,0 +1,157 @@
+import { FindOptions, Op } from 'sequelize';
+import { BaseService } from '../../services/base.service';
+import { FeedConsumptionModel } from './feed-consumption.model';
+import { FeedConsumptionLotModel } from './feed-consumption-lot.model';
+import { FeedConsumptionCreate, FeedConsumptionReason } from './feed-consumption.schema';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+import { decodeId } from '../../utils/id-hash-util';
+import { drainFIFO } from './feed-consumption-fifo';
+
+export interface FeedConsumptionFilters {
+	flockId?: number;
+	feedTypeId?: number;
+	from?: string;
+	to?: string;
+}
+
+export class FeedConsumptionService extends BaseService {
+	async getFeedConsumptions(
+		farmId: number,
+		filters: FeedConsumptionFilters,
+		includeLots: boolean,
+		pagination: PaginationParams,
+	): Promise<PaginatedResult<FeedConsumptionModel>> {
+		const where: Record<string, unknown> = { farmId };
+		if (filters.flockId !== undefined) where.flockId = filters.flockId;
+		if (filters.feedTypeId !== undefined) where.feedTypeId = filters.feedTypeId;
+		if (filters.from || filters.to) {
+			const range: Record<symbol, string> = {};
+			if (filters.from) range[Op.gte] = filters.from;
+			if (filters.to) range[Op.lte] = filters.to;
+			where.consumedAt = range;
+		}
+
+		const findOptions: FindOptions = {
+			where,
+			order: [['consumedAt', 'DESC'], ['id', 'DESC']],
+			...(includeLots && {
+				include: [{ model: this.db.models.FeedConsumptionLot, as: 'lots' }],
+			}),
+		};
+
+		return this.findAllPaginated(this.db.models.FeedConsumption, findOptions, pagination);
+	}
+
+	async getFeedConsumptionById(id: number, farmId: number): Promise<FeedConsumptionModel | null> {
+		return this.db.models.FeedConsumption.findOne({
+			where: { id, farmId },
+			include: [{ model: this.db.models.FeedConsumptionLot, as: 'lots' }],
+		});
+	}
+
+	async createFeedConsumption(
+		farmId: number,
+		createdBy: number,
+		data: FeedConsumptionCreate,
+	): Promise<FeedConsumptionModel> {
+		const feedTypeId = decodeId(data.feedTypeId);
+		if (!feedTypeId) {
+			throw new Error('Invalid feed type ID');
+		}
+
+		const flockId = data.flockId ? decodeId(data.flockId) : null;
+		if (data.flockId && !flockId) {
+			throw new Error('Invalid flock ID');
+		}
+
+		if (data.reason === FeedConsumptionReason.Feeding && !flockId) {
+			throw new Error('A flock is required when reason is "feeding".');
+		}
+
+		return this.db.sequelize.transaction(async (transaction) => {
+			const feedType = await this.db.models.FeedType.findOne({
+				where: { id: feedTypeId, farmId },
+				transaction,
+			});
+			if (!feedType) {
+				throw new Error('Feed type not found');
+			}
+
+			if (flockId !== null) {
+				const flock = await this.db.models.Flock.findOne({
+					where: { id: flockId, farmId },
+					transaction,
+				});
+				if (!flock) {
+					throw new Error('Flock not found');
+				}
+			}
+
+			const draws = await drainFIFO(
+				this.db,
+				{ farmId, feedTypeId, qty: data.qty },
+				transaction,
+			);
+
+			const consumption = await this.db.models.FeedConsumption.create({
+				farmId,
+				flockId,
+				feedTypeId,
+				consumedAt: data.consumedAt,
+				qty: data.qty,
+				reason: data.reason,
+				notes: data.notes ?? null,
+				createdBy,
+			}, { transaction });
+
+			await this.db.models.FeedConsumptionLot.bulkCreate(
+				draws.map(draw => ({
+					consumptionId: consumption.id,
+					lotId: draw.lotId,
+					qtyDrawn: draw.qtyDrawn,
+					unitPriceSnapshot: draw.unitPriceSnapshot,
+				})),
+				{ transaction },
+			);
+
+			return this.db.models.FeedConsumption.findByPk(consumption.id, {
+				include: [{ model: this.db.models.FeedConsumptionLot, as: 'lots' }],
+				transaction,
+			}) as Promise<FeedConsumptionModel>;
+		});
+	}
+
+	async deleteFeedConsumption(id: number, farmId: number): Promise<boolean> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const consumption = await this.db.models.FeedConsumption.findOne({
+				where: { id, farmId },
+				transaction,
+				lock: true,
+			});
+			if (!consumption) {
+				return false;
+			}
+
+			const drawnLots = await this.db.models.FeedConsumptionLot.findAll({
+				where: { consumptionId: consumption.id },
+				transaction,
+			});
+
+			for (const drawn of drawnLots) {
+				await this.db.models.FeedLot.increment('qtyRemaining', {
+					by: Number(drawn.qtyDrawn),
+					where: { id: drawn.lotId },
+					transaction,
+				});
+			}
+
+			// CASCADE on consumption_id deletes feed_consumption_lot rows
+			await consumption.destroy({ transaction });
+			return true;
+		});
+	}
+}
+
+export type FeedConsumptionWithLots = FeedConsumptionModel & {
+	lots?: FeedConsumptionLotModel[];
+};

--- a/src/resources/feed-consumption/index.ts
+++ b/src/resources/feed-consumption/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import feedConsumptionRoutes from './feed-consumption.routes';
+
+const feedConsumptionPlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(feedConsumptionRoutes, { prefix: '/feed-consumptions' });
+};
+
+export default feedConsumptionPlugin;

--- a/src/resources/feed-lot/feed-lot.model.ts
+++ b/src/resources/feed-lot/feed-lot.model.ts
@@ -1,0 +1,101 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { FeedLot } from './feed-lot.schema';
+
+type FeedLotCreationAttributes = Pick<FeedLot, 'farmId' | 'feedTypeId' | 'qtyPurchased' | 'qtyRemaining' | 'unitPrice' | 'purchasedAt' | 'createdBy'> &
+	Partial<Pick<FeedLot, 'supplier' | 'notes'>>;
+
+export class FeedLotModel extends Model<FeedLot, FeedLotCreationAttributes> {
+	declare id: number;
+	declare farmId: number;
+	declare feedTypeId: number;
+	declare qtyPurchased: number;
+	declare qtyRemaining: number;
+	declare unitPrice: number;
+	declare purchasedAt: string;
+	declare supplier: string | null;
+	declare notes: string | null;
+	declare createdBy: number;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFeedLotModel = (sequelize: Sequelize) => FeedLotModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	farmId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'farm_id',
+		references: { model: 'farms', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	feedTypeId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'feed_type_id',
+		references: { model: 'feed_types', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	qtyPurchased: {
+		type: DataTypes.DECIMAL(12, 3),
+		allowNull: false,
+		field: 'qty_purchased',
+	},
+	qtyRemaining: {
+		type: DataTypes.DECIMAL(12, 3),
+		allowNull: false,
+		field: 'qty_remaining',
+	},
+	unitPrice: {
+		type: DataTypes.DECIMAL(12, 2),
+		allowNull: false,
+		field: 'unit_price',
+	},
+	purchasedAt: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+		field: 'purchased_at',
+	},
+	supplier: {
+		type: DataTypes.STRING(255),
+		allowNull: true,
+	},
+	notes: {
+		type: DataTypes.TEXT,
+		allowNull: true,
+	},
+	createdBy: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'created_by',
+		references: { model: 'users', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'feed_lots',
+	modelName: 'FeedLot',
+	timestamps: true,
+	indexes: [
+		{
+			fields: ['farm_id', 'feed_type_id', 'purchased_at', 'id'],
+			name: 'idx_feed_lots_fifo_drain',
+		},
+	],
+});

--- a/src/resources/feed-lot/feed-lot.routes.ts
+++ b/src/resources/feed-lot/feed-lot.routes.ts
@@ -1,0 +1,119 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import { ForeignKeyConstraintError } from 'sequelize';
+import {
+	FeedLotCreate,
+	FeedLotUpdate,
+	FeedLotQuery,
+	FeedLotParams,
+	listFeedLotsSchema,
+	getFeedLotByIdSchema,
+	createFeedLotSchema,
+	updateFeedLotSchema,
+	deleteFeedLotSchema,
+} from './feed-lot.schema';
+import { FeedLotSerializer } from './feed-lot.serializer';
+import { decodeId } from '../../utils/id-hash-util';
+import { parsePagination } from '../../utils/pagination';
+
+const feedLotRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/', { schema: listFeedLotsSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Querystring: FeedLotQuery }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const pagination = parsePagination(request.query);
+
+			const filters: { feedTypeId?: number; hasStock?: boolean } = {};
+			if (request.query.feedTypeId) {
+				const decoded = decodeId(request.query.feedTypeId);
+				if (!decoded) {
+					return reply.error('Invalid feed type ID', 400);
+				}
+				filters.feedTypeId = decoded;
+			}
+			if (request.query.hasStock !== undefined) {
+				filters.hasStock = request.query.hasStock;
+			}
+
+			const result = await fastify.feedLotService.getFeedLots(farmId, filters, pagination);
+			reply.successWithPagination(FeedLotSerializer.serializeMany(result.rows), result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/:id', { schema: getFeedLotByIdSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedLotParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const lotId = decodeId(request.params.id);
+			if (!lotId) {
+				return reply.error('Invalid feed lot ID', 400);
+			}
+
+			const lot = await fastify.feedLotService.getFeedLotById(lotId, farmId);
+			if (!lot) {
+				return reply.error('Feed lot not found', 404);
+			}
+
+			reply.success(FeedLotSerializer.serialize(lot));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/', { schema: createFeedLotSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Body: FeedLotCreate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const userId = request.user!.id;
+			const lot = await fastify.feedLotService.createFeedLot(farmId, userId, request.body);
+			reply.success(FeedLotSerializer.serialize(lot));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.put('/:id', { schema: updateFeedLotSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedLotParams; Body: FeedLotUpdate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const lotId = decodeId(request.params.id);
+			if (!lotId) {
+				return reply.error('Invalid feed lot ID', 400);
+			}
+
+			const lot = await fastify.feedLotService.updateFeedLot(lotId, farmId, request.body);
+			if (!lot) {
+				return reply.error('Feed lot not found', 404);
+			}
+
+			reply.success(FeedLotSerializer.serialize(lot));
+		} catch (error) {
+			if (error instanceof Error && error.name === 'LotImmutableError') {
+				return reply.error(error.message, 422);
+			}
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/:id', { schema: deleteFeedLotSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedLotParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const lotId = decodeId(request.params.id);
+			if (!lotId) {
+				return reply.error('Invalid feed lot ID', 400);
+			}
+
+			const deleted = await fastify.feedLotService.deleteFeedLot(lotId, farmId);
+			if (!deleted) {
+				return reply.error('Feed lot not found', 404);
+			}
+
+			reply.success(null, 'Feed lot deleted successfully');
+		} catch (error) {
+			if (error instanceof ForeignKeyConstraintError) {
+				return reply.error('This feed lot has consumption history and cannot be deleted', 409);
+			}
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default feedLotRoutes;

--- a/src/resources/feed-lot/feed-lot.schema.ts
+++ b/src/resources/feed-lot/feed-lot.schema.ts
@@ -1,0 +1,110 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createGetEndpointSchema,
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createUpdateEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+const FeedLotSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	farmId: Type.Integer(),
+	feedTypeId: Type.Integer(),
+	qtyPurchased: Type.Number(),
+	qtyRemaining: Type.Number(),
+	unitPrice: Type.Number(),
+	purchasedAt: Type.String(),
+	supplier: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	notes: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	createdBy: Type.Integer(),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'feedLot',
+	additionalProperties: false,
+});
+
+export const FeedLotResponseSchema = Type.Object({
+	...FeedLotSchema.properties,
+	id: Type.String(),
+	farmId: Type.String(),
+	feedTypeId: Type.String(),
+	createdBy: Type.String(),
+}, {
+	$id: 'feedLotResponse',
+	additionalProperties: false,
+});
+
+export const FeedLotCreateSchema = Type.Object({
+	feedTypeId: Type.String(),
+	qtyPurchased: Type.Number({ exclusiveMinimum: 0 }),
+	unitPrice: Type.Number({ minimum: 0 }),
+	purchasedAt: Type.String({ format: 'date' }),
+	supplier: Type.Optional(Type.String({ maxLength: 255 })),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'feedLotCreate',
+	additionalProperties: false,
+});
+
+export const FeedLotUpdateSchema = Type.Object({
+	unitPrice: Type.Optional(Type.Number({ minimum: 0 })),
+	supplier: Type.Optional(Type.String({ maxLength: 255 })),
+	notes: Type.Optional(Type.String()),
+	purchasedAt: Type.Optional(Type.String({ format: 'date' })),
+}, {
+	$id: 'feedLotUpdate',
+	additionalProperties: false,
+});
+
+export const FeedLotQuerySchema = Type.Object({
+	feedTypeId: Type.Optional(Type.String()),
+	hasStock: Type.Optional(Type.Boolean()),
+	...PaginationQueryProps,
+}, {
+	$id: 'feedLotQuery',
+	additionalProperties: false,
+});
+
+export const FeedLotParamsSchema = Type.Object({
+	id: Type.String(),
+});
+
+export type FeedLot = Static<typeof FeedLotSchema>;
+export type FeedLotResponse = Static<typeof FeedLotResponseSchema>;
+export type FeedLotCreate = Static<typeof FeedLotCreateSchema>;
+export type FeedLotUpdate = Static<typeof FeedLotUpdateSchema>;
+export type FeedLotQuery = Static<typeof FeedLotQuerySchema>;
+export type FeedLotParams = Static<typeof FeedLotParamsSchema>;
+
+export const listFeedLotsSchema = createListEndpointSchema({
+	querystring: FeedLotQuerySchema,
+	dataSchema: Type.Array(FeedLotResponseSchema),
+	errorCodes: [400],
+});
+
+export const getFeedLotByIdSchema = createGetEndpointSchema({
+	params: FeedLotParamsSchema,
+	dataSchema: FeedLotResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const createFeedLotSchema = createPostEndpointSchema({
+	body: FeedLotCreateSchema,
+	dataSchema: FeedLotResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const updateFeedLotSchema = createUpdateEndpointSchema({
+	params: FeedLotParamsSchema,
+	body: FeedLotUpdateSchema,
+	dataSchema: FeedLotResponseSchema,
+	errorCodes: [400, 404, 422],
+});
+
+export const deleteFeedLotSchema = createDeleteEndpointSchema({
+	params: FeedLotParamsSchema,
+	errorCodes: [400, 404, 409],
+});

--- a/src/resources/feed-lot/feed-lot.serializer.ts
+++ b/src/resources/feed-lot/feed-lot.serializer.ts
@@ -1,0 +1,26 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FeedLotModel } from './feed-lot.model';
+import { FeedLotResponse } from './feed-lot.schema';
+
+export class FeedLotSerializer {
+	static serialize(lot: FeedLotModel): FeedLotResponse {
+		return {
+			id: encodeId(lot.id),
+			farmId: encodeId(lot.farmId),
+			feedTypeId: encodeId(lot.feedTypeId),
+			qtyPurchased: Number(lot.qtyPurchased),
+			qtyRemaining: Number(lot.qtyRemaining),
+			unitPrice: Number(lot.unitPrice),
+			purchasedAt: lot.purchasedAt,
+			supplier: lot.supplier,
+			notes: lot.notes,
+			createdBy: encodeId(lot.createdBy),
+			createdAt: lot.createdAt,
+			updatedAt: lot.updatedAt,
+		};
+	}
+
+	static serializeMany(lots: FeedLotModel[]): FeedLotResponse[] {
+		return lots.map(l => this.serialize(l));
+	}
+}

--- a/src/resources/feed-lot/feed-lot.service.ts
+++ b/src/resources/feed-lot/feed-lot.service.ts
@@ -1,0 +1,116 @@
+import { FindOptions, Op } from 'sequelize';
+import { BaseService } from '../../services/base.service';
+import { FeedLotModel } from './feed-lot.model';
+import { FeedLotCreate, FeedLotUpdate } from './feed-lot.schema';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+import { decodeId } from '../../utils/id-hash-util';
+
+export class LotImmutableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'LotImmutableError';
+	}
+}
+
+export class FeedLotService extends BaseService {
+	async getFeedLots(
+		farmId: number,
+		filters: { feedTypeId?: number; hasStock?: boolean },
+		pagination: PaginationParams,
+	): Promise<PaginatedResult<FeedLotModel>> {
+		const where: Record<string, unknown> = { farmId };
+		if (filters.feedTypeId !== undefined) {
+			where.feedTypeId = filters.feedTypeId;
+		}
+		if (filters.hasStock) {
+			where.qtyRemaining = { [Op.gt]: 0 };
+		}
+
+		const findOptions: FindOptions = {
+			where,
+			order: [['purchasedAt', 'DESC'], ['id', 'DESC']],
+		};
+
+		return this.findAllPaginated(this.db.models.FeedLot, findOptions, pagination);
+	}
+
+	async getFeedLotById(id: number, farmId: number): Promise<FeedLotModel | null> {
+		return this.db.models.FeedLot.findOne({ where: { id, farmId } });
+	}
+
+	async createFeedLot(farmId: number, createdBy: number, data: FeedLotCreate): Promise<FeedLotModel> {
+		const feedTypeId = decodeId(data.feedTypeId);
+		if (!feedTypeId) {
+			throw new Error('Invalid feed type ID');
+		}
+
+		return this.db.sequelize.transaction(async (transaction) => {
+			const feedType = await this.db.models.FeedType.findOne({
+				where: { id: feedTypeId, farmId },
+				transaction,
+			});
+			if (!feedType) {
+				throw new Error('Feed type not found');
+			}
+
+			return this.db.models.FeedLot.create({
+				farmId,
+				feedTypeId,
+				qtyPurchased: data.qtyPurchased,
+				qtyRemaining: data.qtyPurchased,
+				unitPrice: data.unitPrice,
+				purchasedAt: data.purchasedAt,
+				supplier: data.supplier ?? null,
+				notes: data.notes ?? null,
+				createdBy,
+			}, { transaction });
+		});
+	}
+
+	async updateFeedLot(id: number, farmId: number, data: FeedLotUpdate): Promise<FeedLotModel | null> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const lot = await this.db.models.FeedLot.findOne({
+				where: { id, farmId },
+				transaction,
+				lock: true,
+			});
+
+			if (!lot) {
+				return null;
+			}
+
+			const isImmutable = Number(lot.qtyRemaining) !== Number(lot.qtyPurchased);
+			const wantsPriceChange = data.unitPrice !== undefined && Number(data.unitPrice) !== Number(lot.unitPrice);
+			const wantsDateChange = data.purchasedAt !== undefined && data.purchasedAt !== lot.purchasedAt;
+
+			if (isImmutable && (wantsPriceChange || wantsDateChange)) {
+				throw new LotImmutableError('Cannot edit price or purchase date after the lot has been partially consumed.');
+			}
+
+			const updates: Record<string, unknown> = {};
+			if (data.unitPrice !== undefined) updates.unitPrice = data.unitPrice;
+			if (data.purchasedAt !== undefined) updates.purchasedAt = data.purchasedAt;
+			if (data.supplier !== undefined) updates.supplier = data.supplier;
+			if (data.notes !== undefined) updates.notes = data.notes;
+
+			await lot.update(updates, { transaction });
+			return lot;
+		});
+	}
+
+	async deleteFeedLot(id: number, farmId: number): Promise<boolean> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const lot = await this.db.models.FeedLot.findOne({
+				where: { id, farmId },
+				transaction,
+			});
+
+			if (!lot) {
+				return false;
+			}
+
+			await lot.destroy({ transaction });
+			return true;
+		});
+	}
+}

--- a/src/resources/feed-lot/index.ts
+++ b/src/resources/feed-lot/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import feedLotRoutes from './feed-lot.routes';
+
+const feedLotPlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(feedLotRoutes, { prefix: '/feed-lots' });
+};
+
+export default feedLotPlugin;

--- a/src/resources/feed-type/feed-type.model.ts
+++ b/src/resources/feed-type/feed-type.model.ts
@@ -1,0 +1,61 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { FeedType } from './feed-type.schema';
+
+type FeedTypeCreationAttributes = Pick<FeedType, 'farmId' | 'name'> & Partial<Pick<FeedType, 'notes'>>;
+
+export class FeedTypeModel extends Model<FeedType, FeedTypeCreationAttributes> {
+	declare id: number;
+	declare farmId: number;
+	declare name: string;
+	declare notes: string | null;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFeedTypeModel = (sequelize: Sequelize) => FeedTypeModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	farmId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'farm_id',
+		references: { model: 'farms', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	name: {
+		type: DataTypes.STRING(120),
+		allowNull: false,
+	},
+	notes: {
+		type: DataTypes.TEXT,
+		allowNull: true,
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'feed_types',
+	modelName: 'FeedType',
+	timestamps: true,
+	indexes: [
+		{
+			unique: true,
+			fields: ['farm_id', 'name'],
+			name: 'idx_feed_types_farm_name_unique',
+		},
+	],
+});

--- a/src/resources/feed-type/feed-type.routes.ts
+++ b/src/resources/feed-type/feed-type.routes.ts
@@ -1,0 +1,102 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import { ForeignKeyConstraintError } from 'sequelize';
+import {
+	FeedTypeCreate,
+	FeedTypeUpdate,
+	FeedTypeQuery,
+	FeedTypeParams,
+	listFeedTypesSchema,
+	getFeedTypeByIdSchema,
+	createFeedTypeSchema,
+	updateFeedTypeSchema,
+	deleteFeedTypeSchema,
+} from './feed-type.schema';
+import { FeedTypeSerializer } from './feed-type.serializer';
+import { decodeId } from '../../utils/id-hash-util';
+import { parsePagination } from '../../utils/pagination';
+
+const feedTypeRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/', { schema: listFeedTypesSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Querystring: FeedTypeQuery }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const pagination = parsePagination(request.query);
+			const result = await fastify.feedTypeService.getFeedTypes(farmId, pagination);
+			reply.successWithPagination(FeedTypeSerializer.serializeMany(result.rows), result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/:id', { schema: getFeedTypeByIdSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedTypeParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const feedTypeId = decodeId(request.params.id);
+			if (!feedTypeId) {
+				return reply.error('Invalid feed type ID', 400);
+			}
+
+			const feedType = await fastify.feedTypeService.getFeedTypeById(feedTypeId, farmId);
+			if (!feedType) {
+				return reply.error('Feed type not found', 404);
+			}
+
+			reply.success(FeedTypeSerializer.serialize(feedType));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/', { schema: createFeedTypeSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Body: FeedTypeCreate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const feedType = await fastify.feedTypeService.createFeedType(farmId, request.body);
+			reply.success(FeedTypeSerializer.serialize(feedType));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.put('/:id', { schema: updateFeedTypeSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedTypeParams; Body: FeedTypeUpdate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const feedTypeId = decodeId(request.params.id);
+			if (!feedTypeId) {
+				return reply.error('Invalid feed type ID', 400);
+			}
+
+			const feedType = await fastify.feedTypeService.updateFeedType(feedTypeId, farmId, request.body);
+			if (!feedType) {
+				return reply.error('Feed type not found', 404);
+			}
+
+			reply.success(FeedTypeSerializer.serialize(feedType));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/:id', { schema: deleteFeedTypeSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedTypeParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const feedTypeId = decodeId(request.params.id);
+			if (!feedTypeId) {
+				return reply.error('Invalid feed type ID', 400);
+			}
+
+			const deleted = await fastify.feedTypeService.deleteFeedType(feedTypeId, farmId);
+			if (!deleted) {
+				return reply.error('Feed type not found', 404);
+			}
+
+			reply.success(null, 'Feed type deleted successfully');
+		} catch (error) {
+			if (error instanceof ForeignKeyConstraintError) {
+				return reply.error('This feed type has lots or consumption history and cannot be deleted', 409);
+			}
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default feedTypeRoutes;

--- a/src/resources/feed-type/feed-type.schema.ts
+++ b/src/resources/feed-type/feed-type.schema.ts
@@ -1,0 +1,94 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createGetEndpointSchema,
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createUpdateEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+const FeedTypeSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	farmId: Type.Integer(),
+	name: Type.String(),
+	notes: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'feedType',
+	additionalProperties: false,
+});
+
+export const FeedTypeResponseSchema = Type.Object({
+	...FeedTypeSchema.properties,
+	id: Type.String(),
+	farmId: Type.String(),
+}, {
+	$id: 'feedTypeResponse',
+	additionalProperties: false,
+});
+
+export const FeedTypeCreateSchema = Type.Object({
+	name: Type.String({ minLength: 1, maxLength: 120 }),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'feedTypeCreate',
+	additionalProperties: false,
+});
+
+export const FeedTypeUpdateSchema = Type.Object({
+	name: Type.Optional(Type.String({ minLength: 1, maxLength: 120 })),
+	notes: Type.Optional(Type.String()),
+}, {
+	$id: 'feedTypeUpdate',
+	additionalProperties: false,
+});
+
+export const FeedTypeQuerySchema = Type.Object({
+	...PaginationQueryProps,
+}, {
+	$id: 'feedTypeQuery',
+	additionalProperties: false,
+});
+
+export const FeedTypeParamsSchema = Type.Object({
+	id: Type.String(),
+});
+
+export type FeedType = Static<typeof FeedTypeSchema>;
+export type FeedTypeResponse = Static<typeof FeedTypeResponseSchema>;
+export type FeedTypeCreate = Static<typeof FeedTypeCreateSchema>;
+export type FeedTypeUpdate = Static<typeof FeedTypeUpdateSchema>;
+export type FeedTypeQuery = Static<typeof FeedTypeQuerySchema>;
+export type FeedTypeParams = Static<typeof FeedTypeParamsSchema>;
+
+export const listFeedTypesSchema = createListEndpointSchema({
+	querystring: FeedTypeQuerySchema,
+	dataSchema: Type.Array(FeedTypeResponseSchema),
+	errorCodes: [400],
+});
+
+export const getFeedTypeByIdSchema = createGetEndpointSchema({
+	params: FeedTypeParamsSchema,
+	dataSchema: FeedTypeResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const createFeedTypeSchema = createPostEndpointSchema({
+	body: FeedTypeCreateSchema,
+	dataSchema: FeedTypeResponseSchema,
+	errorCodes: [400, 409],
+});
+
+export const updateFeedTypeSchema = createUpdateEndpointSchema({
+	params: FeedTypeParamsSchema,
+	body: FeedTypeUpdateSchema,
+	dataSchema: FeedTypeResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const deleteFeedTypeSchema = createDeleteEndpointSchema({
+	params: FeedTypeParamsSchema,
+	errorCodes: [400, 404, 409],
+});

--- a/src/resources/feed-type/feed-type.serializer.ts
+++ b/src/resources/feed-type/feed-type.serializer.ts
@@ -1,0 +1,20 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FeedTypeModel } from './feed-type.model';
+import { FeedTypeResponse } from './feed-type.schema';
+
+export class FeedTypeSerializer {
+	static serialize(feedType: FeedTypeModel): FeedTypeResponse {
+		return {
+			id: encodeId(feedType.id),
+			farmId: encodeId(feedType.farmId),
+			name: feedType.name,
+			notes: feedType.notes,
+			createdAt: feedType.createdAt,
+			updatedAt: feedType.updatedAt,
+		};
+	}
+
+	static serializeMany(feedTypes: FeedTypeModel[]): FeedTypeResponse[] {
+		return feedTypes.map(f => this.serialize(f));
+	}
+}

--- a/src/resources/feed-type/feed-type.service.ts
+++ b/src/resources/feed-type/feed-type.service.ts
@@ -1,0 +1,84 @@
+import { FindOptions, Op } from 'sequelize';
+import { BaseService } from '../../services/base.service';
+import { FeedTypeModel } from './feed-type.model';
+import { FeedTypeCreate, FeedTypeUpdate } from './feed-type.schema';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+
+export class FeedTypeService extends BaseService {
+	async getFeedTypes(farmId: number, pagination: PaginationParams): Promise<PaginatedResult<FeedTypeModel>> {
+		const findOptions: FindOptions = {
+			where: { farmId },
+			order: [['name', 'ASC']],
+		};
+
+		return this.findAllPaginated(this.db.models.FeedType, findOptions, pagination);
+	}
+
+	async getFeedTypeById(id: number, farmId: number): Promise<FeedTypeModel | null> {
+		return this.db.models.FeedType.findOne({ where: { id, farmId } });
+	}
+
+	async createFeedType(farmId: number, data: FeedTypeCreate): Promise<FeedTypeModel> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			await this.assertNameAvailable(data.name, farmId, transaction);
+			return this.db.models.FeedType.create({
+				farmId,
+				name: data.name,
+				notes: data.notes ?? null,
+			}, { transaction });
+		});
+	}
+
+	async updateFeedType(id: number, farmId: number, data: FeedTypeUpdate): Promise<FeedTypeModel | null> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const feedType = await this.db.models.FeedType.findOne({
+				where: { id, farmId },
+				transaction,
+				lock: true,
+			});
+
+			if (!feedType) {
+				return null;
+			}
+
+			if (data.name && data.name !== feedType.name) {
+				await this.assertNameAvailable(data.name, farmId, transaction, id);
+			}
+
+			await feedType.update(data, { transaction });
+			return feedType;
+		});
+	}
+
+	async deleteFeedType(id: number, farmId: number): Promise<boolean> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const feedType = await this.db.models.FeedType.findOne({
+				where: { id, farmId },
+				transaction,
+			});
+
+			if (!feedType) {
+				return false;
+			}
+
+			await feedType.destroy({ transaction });
+			return true;
+		});
+	}
+
+	private async assertNameAvailable(
+		name: string,
+		farmId: number,
+		transaction: import('sequelize').Transaction,
+		excludeId?: number,
+	): Promise<void> {
+		const where: Record<string, unknown> = { farmId, name };
+		if (excludeId) {
+			where.id = { [Op.ne]: excludeId };
+		}
+		const existing = await this.db.models.FeedType.findOne({ where, transaction });
+		if (existing) {
+			throw new Error('A feed type with this name already exists on this farm.');
+		}
+	}
+}

--- a/src/resources/feed-type/index.ts
+++ b/src/resources/feed-type/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import feedTypeRoutes from './feed-type.routes';
+
+const feedTypePlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(feedTypeRoutes, { prefix: '/feed-types' });
+};
+
+export default feedTypePlugin;

--- a/src/utils/schema-builder.ts
+++ b/src/utils/schema-builder.ts
@@ -29,6 +29,7 @@ export const CommonErrorResponses = {
 	400: ErrorResponseSchema,
 	404: ErrorResponseSchema,
 	409: ErrorResponseSchema,
+	422: ErrorResponseSchema,
 	500: ErrorResponseSchema,
 } as const;
 
@@ -41,7 +42,7 @@ export interface EndpointSchemaConfig {
     querystring?: TSchema
     successCode: 200 | 201 | 204
     dataSchema?: TSchema
-    errorCodes?: (400 | 404 | 409 | 500)[]
+    errorCodes?: (400 | 404 | 409 | 422 | 500)[]
 }
 
 /**

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -141,6 +141,49 @@ export async function createFlock(
 	};
 }
 
+export async function createFeedType(
+	app: FastifyInstance,
+	farmId: number,
+	overrides?: { name?: string; notes?: string },
+): Promise<{ feedTypeId: number; encodedFeedTypeId: string }> {
+	const feedType = await app.db.models.FeedType.create({
+		farmId,
+		name: overrides?.name ?? `Feed-${Date.now()}`,
+		notes: overrides?.notes ?? null,
+	});
+
+	return {
+		feedTypeId: feedType.dataValues.id,
+		encodedFeedTypeId: encodeId(feedType.dataValues.id),
+	};
+}
+
+export async function createFeedLot(
+	app: FastifyInstance,
+	farmId: number,
+	feedTypeId: number,
+	createdBy: number,
+	overrides?: { qtyPurchased?: number; unitPrice?: number; purchasedAt?: string; supplier?: string; notes?: string },
+): Promise<{ feedLotId: number; encodedFeedLotId: string }> {
+	const qty = overrides?.qtyPurchased ?? 10;
+	const lot = await app.db.models.FeedLot.create({
+		farmId,
+		feedTypeId,
+		qtyPurchased: qty,
+		qtyRemaining: qty,
+		unitPrice: overrides?.unitPrice ?? 1,
+		purchasedAt: overrides?.purchasedAt ?? '2026-01-01',
+		supplier: overrides?.supplier ?? null,
+		notes: overrides?.notes ?? null,
+		createdBy,
+	});
+
+	return {
+		feedLotId: lot.dataValues.id,
+		encodedFeedLotId: encodeId(lot.dataValues.id),
+	};
+}
+
 export async function createFinancialTransaction(
 	app: FastifyInstance,
 	farmId: number,

--- a/tests/integration/feed-consumption.test.ts
+++ b/tests/integration/feed-consumption.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import { createSpecies, createBreed, createFlock, createFeedType, createFeedLot } from '../helpers/factories';
+import { encodeId } from '../../src/utils/id-hash-util';
+
+async function setupFeedingScenario(app: FastifyInstance) {
+	const { user, cookie } = await createAuthenticatedUser(app);
+	const { speciesId } = await createSpecies(app);
+	const { breedId } = await createBreed(app, speciesId);
+	const { flockId, encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId);
+	const { feedTypeId, encodedFeedTypeId } = await createFeedType(app, user.farmId);
+	return { user, cookie, flockId, encodedFlockId, feedTypeId, encodedFeedTypeId };
+}
+
+describe('Feed consumption endpoints', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('POST /api/v1/feed-consumptions — FIFO drain', () => {
+		it('drains the oldest lot first when capacity covers the request', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			const { feedLotId: lot1Id } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10, unitPrice: 1, purchasedAt: '2026-01-01',
+			});
+			await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 5, unitPrice: 2, purchasedAt: '2026-02-01',
+			});
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qty: 8,
+					consumedAt: '2026-02-15',
+					reason: 'feeding',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.lots).toHaveLength(1);
+			expect(body.data.lots[0].lotId).toBe(encodeId(lot1Id));
+			expect(body.data.lots[0].qtyDrawn).toBe(8);
+			expect(body.data.lots[0].unitPriceSnapshot).toBe(1);
+			expect(body.data.totalCost).toBe(8);
+
+			const reloadedLot1 = await app.db.models.FeedLot.findByPk(lot1Id);
+			expect(Number(reloadedLot1!.qtyRemaining)).toBe(2);
+		});
+
+		it('spans multiple lots when one is not enough', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			const { feedLotId: lot1Id } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 3, unitPrice: 1, purchasedAt: '2026-01-01',
+			});
+			const { feedLotId: lot2Id } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 3, unitPrice: 2, purchasedAt: '2026-01-02',
+			});
+			const { feedLotId: lot3Id } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 3, unitPrice: 3, purchasedAt: '2026-01-03',
+			});
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qty: 7,
+					consumedAt: '2026-01-10',
+					reason: 'feeding',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.lots).toHaveLength(3);
+			expect(body.data.totalCost).toBe(3 * 1 + 3 * 2 + 1 * 3);
+
+			const lot3 = await app.db.models.FeedLot.findByPk(lot3Id);
+			expect(Number(lot3!.qtyRemaining)).toBe(2);
+
+			const lot1 = await app.db.models.FeedLot.findByPk(lot1Id);
+			expect(Number(lot1!.qtyRemaining)).toBe(0);
+			const lot2 = await app.db.models.FeedLot.findByPk(lot2Id);
+			expect(Number(lot2!.qtyRemaining)).toBe(0);
+		});
+
+		it('rejects with 422 when total stock is less than requested', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			const { feedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 5, unitPrice: 1,
+			});
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qty: 6,
+					consumedAt: '2026-02-01',
+					reason: 'feeding',
+				},
+			});
+
+			expect(response.statusCode).toBe(422);
+
+			const consumptions = await app.db.models.FeedConsumption.findAll();
+			expect(consumptions).toHaveLength(0);
+			const consumptionLots = await app.db.models.FeedConsumptionLot.findAll();
+			expect(consumptionLots).toHaveLength(0);
+
+			const lot = await app.db.models.FeedLot.findByPk(feedLotId);
+			expect(Number(lot!.qtyRemaining)).toBe(5);
+		});
+
+		it('rejects with 422 when no lots exist at all', async () => {
+			const { cookie, encodedFlockId, encodedFeedTypeId } = await setupFeedingScenario(app);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'feeding',
+				},
+			});
+
+			expect(response.statusCode).toBe(422);
+		});
+
+		it('does not retroactively rewrite past consumptions when a lot is backdated', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			const { feedLotId: lotAId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10, unitPrice: 5, purchasedAt: '2026-03-01',
+			});
+
+			const firstResponse = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId, feedTypeId: encodedFeedTypeId,
+					qty: 4, consumedAt: '2026-03-10', reason: 'feeding',
+				},
+			});
+			const firstBody = firstResponse.json();
+			expect(firstBody.data.lots[0].lotId).toBe(encodeId(lotAId));
+			expect(firstBody.data.lots[0].unitPriceSnapshot).toBe(5);
+
+			const { feedLotId: lotBId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10, unitPrice: 1, purchasedAt: '2026-02-01',
+			});
+
+			const oldConsumptionLots = await app.db.models.FeedConsumptionLot.findAll();
+			expect(oldConsumptionLots).toHaveLength(1);
+			expect(oldConsumptionLots[0].lotId).toBe(lotAId);
+			expect(Number(oldConsumptionLots[0].unitPriceSnapshot)).toBe(5);
+
+			const secondResponse = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId, feedTypeId: encodedFeedTypeId,
+					qty: 3, consumedAt: '2026-03-15', reason: 'feeding',
+				},
+			});
+			const secondBody = secondResponse.json();
+			expect(secondBody.data.lots[0].lotId).toBe(encodeId(lotBId));
+			expect(secondBody.data.lots[0].unitPriceSnapshot).toBe(1);
+		});
+
+		it('rejects feeding consumption without a flock', async () => {
+			const { cookie, encodedFeedTypeId } = await setupFeedingScenario(app);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'feeding',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('allows waste consumption without a flock', async () => {
+			const { user, cookie, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			await createFeedLot(app, user.farmId, feedTypeId, user.id, { qtyPurchased: 5 });
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'waste',
+				},
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json().data.flockId).toBeNull();
+		});
+	});
+
+	describe('DELETE /api/v1/feed-consumptions/:id', () => {
+		it('reverses the drain and restores lot qtyRemaining', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			const { feedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10, unitPrice: 1,
+			});
+
+			const createResponse = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId, feedTypeId: encodedFeedTypeId,
+					qty: 5, consumedAt: '2026-02-01', reason: 'feeding',
+				},
+			});
+			const consumptionId = createResponse.json().data.id;
+
+			const lotAfterCreate = await app.db.models.FeedLot.findByPk(feedLotId);
+			expect(Number(lotAfterCreate!.qtyRemaining)).toBe(5);
+
+			const deleteResponse = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/feed-consumptions/${consumptionId}`,
+				headers: { cookie },
+			});
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const lotAfterDelete = await app.db.models.FeedLot.findByPk(feedLotId);
+			expect(Number(lotAfterDelete!.qtyRemaining)).toBe(10);
+
+			const remainingLinks = await app.db.models.FeedConsumptionLot.findAll();
+			expect(remainingLinks).toHaveLength(0);
+		});
+	});
+
+	describe('GET /api/v1/feed-consumptions', () => {
+		it('lists consumptions with lots when include=lots', async () => {
+			const { user, cookie, encodedFlockId, feedTypeId, encodedFeedTypeId } = await setupFeedingScenario(app);
+			await createFeedLot(app, user.farmId, feedTypeId, user.id, { qtyPurchased: 10 });
+
+			await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId, feedTypeId: encodedFeedTypeId,
+					qty: 2, consumedAt: '2026-02-01', reason: 'feeding',
+				},
+			});
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/feed-consumptions?include=lots',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+			expect(body.data[0].lots).toHaveLength(1);
+		});
+	});
+});

--- a/tests/integration/feed-lot.test.ts
+++ b/tests/integration/feed-lot.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import { createFeedType, createFeedLot } from '../helpers/factories';
+import { encodeId } from '../../src/utils/id-hash-util';
+
+describe('Feed lot endpoints', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('POST /api/v1/feed-lots', () => {
+		it('returns 401 when not authenticated', async () => {
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-lots',
+				payload: { feedTypeId: 'fake', qtyPurchased: 10, unitPrice: 2, purchasedAt: '2026-01-01' },
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('creates a feed lot with qtyRemaining equal to qtyPurchased', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { encodedFeedTypeId } = await createFeedType(app, user.farmId, { name: 'Hay' });
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-lots',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qtyPurchased: 25,
+					unitPrice: 1.5,
+					purchasedAt: '2026-01-15',
+					supplier: 'Supplier A',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.qtyPurchased).toBe(25);
+			expect(body.data.qtyRemaining).toBe(25);
+			expect(body.data.unitPrice).toBe(1.5);
+			expect(body.data.supplier).toBe('Supplier A');
+		});
+
+		it('rejects creation when feed type does not exist on this farm', async () => {
+			const { cookie } = await createAuthenticatedUser(app);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-lots',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodeId(99999),
+					qtyPurchased: 10,
+					unitPrice: 1,
+					purchasedAt: '2026-01-01',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+	});
+
+	describe('PUT /api/v1/feed-lots/:id', () => {
+		it('allows price edit on an untouched lot', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId } = await createFeedType(app, user.farmId);
+			const { encodedFeedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10,
+				unitPrice: 1,
+			});
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/feed-lots/${encodedFeedLotId}`,
+				headers: { cookie },
+				payload: { unitPrice: 2 },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.unitPrice).toBe(2);
+		});
+
+		it('returns 422 when editing price on a partially consumed lot', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId, encodedFeedTypeId } = await createFeedType(app, user.farmId);
+			const { encodedFeedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10,
+				unitPrice: 1,
+			});
+
+			await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'waste',
+				},
+			});
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/feed-lots/${encodedFeedLotId}`,
+				headers: { cookie },
+				payload: { unitPrice: 5 },
+			});
+
+			expect(response.statusCode).toBe(422);
+			expect(response.json().message).toMatch(/cannot edit price/i);
+		});
+
+		it('allows non-price edits (notes) on partially consumed lot', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId, encodedFeedTypeId } = await createFeedType(app, user.farmId);
+			const { encodedFeedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10,
+				unitPrice: 1,
+			});
+
+			await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'waste',
+				},
+			});
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/feed-lots/${encodedFeedLotId}`,
+				headers: { cookie },
+				payload: { notes: 'Updated notes' },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.notes).toBe('Updated notes');
+		});
+	});
+
+	describe('DELETE /api/v1/feed-lots/:id', () => {
+		it('deletes an unused lot', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId } = await createFeedType(app, user.farmId);
+			const { encodedFeedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id);
+
+			const response = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/feed-lots/${encodedFeedLotId}`,
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(200);
+		});
+
+		it('returns 409 when the lot has consumption history', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId, encodedFeedTypeId } = await createFeedType(app, user.farmId);
+			const { encodedFeedLotId } = await createFeedLot(app, user.farmId, feedTypeId, user.id, {
+				qtyPurchased: 10,
+			});
+
+			await app.inject({
+				method: 'POST',
+				url: '/api/v1/feed-consumptions',
+				headers: { cookie },
+				payload: {
+					feedTypeId: encodedFeedTypeId,
+					qty: 1,
+					consumedAt: '2026-02-01',
+					reason: 'waste',
+				},
+			});
+
+			const response = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/feed-lots/${encodedFeedLotId}`,
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(409);
+		});
+	});
+
+	describe('GET /api/v1/feed-lots', () => {
+		it('lists lots scoped to the current farm', async () => {
+			const { user, cookie } = await createAuthenticatedUser(app);
+			const { feedTypeId } = await createFeedType(app, user.farmId);
+			await createFeedLot(app, user.farmId, feedTypeId, user.id, { purchasedAt: '2026-01-01' });
+			await createFeedLot(app, user.farmId, feedTypeId, user.id, { purchasedAt: '2026-02-01' });
+
+			const response = await app.inject({
+				method: 'GET',
+				url: '/api/v1/feed-lots',
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(2);
+			expect(body.meta.pagination.total).toBe(2);
+		});
+	});
+});

--- a/tests/unit/feed-consumption-fifo.test.ts
+++ b/tests/unit/feed-consumption-fifo.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { computeDraws, InsufficientStockError, DrainableLot } from '../../src/resources/feed-consumption/feed-consumption-fifo';
+
+function lot(id: number, qtyRemaining: number, unitPrice: number): DrainableLot {
+	return { id, qtyRemaining, unitPrice };
+}
+
+describe('computeDraws', () => {
+	it('drains a single lot when capacity covers the request', () => {
+		const lots = [lot(1, 10, 1)];
+
+		const draws = computeDraws(lots, 8);
+
+		expect(draws).toEqual([
+			{ lotId: 1, qtyDrawn: 8, unitPriceSnapshot: 1 },
+		]);
+	});
+
+	it('drains the oldest lot first when multiple lots have stock', () => {
+		const lots = [lot(1, 10, 1), lot(2, 5, 2)];
+
+		const draws = computeDraws(lots, 8);
+
+		expect(draws).toEqual([
+			{ lotId: 1, qtyDrawn: 8, unitPriceSnapshot: 1 },
+		]);
+	});
+
+	it('spans across two lots when the first does not cover the request', () => {
+		const lots = [lot(1, 10, 1), lot(2, 5, 2)];
+
+		const draws = computeDraws(lots, 12);
+
+		expect(draws).toEqual([
+			{ lotId: 1, qtyDrawn: 10, unitPriceSnapshot: 1 },
+			{ lotId: 2, qtyDrawn: 2, unitPriceSnapshot: 2 },
+		]);
+	});
+
+	it('spans across three lots with mixed prices', () => {
+		const lots = [lot(1, 3, 1), lot(2, 3, 2), lot(3, 3, 3)];
+
+		const draws = computeDraws(lots, 7);
+
+		expect(draws).toEqual([
+			{ lotId: 1, qtyDrawn: 3, unitPriceSnapshot: 1 },
+			{ lotId: 2, qtyDrawn: 3, unitPriceSnapshot: 2 },
+			{ lotId: 3, qtyDrawn: 1, unitPriceSnapshot: 3 },
+		]);
+	});
+
+	it('throws InsufficientStockError when total stock is less than requested', () => {
+		const lots = [lot(1, 3, 1), lot(2, 1, 2)];
+
+		expect(() => computeDraws(lots, 5)).toThrow(InsufficientStockError);
+	});
+
+	it('throws InsufficientStockError when no lots are available', () => {
+		expect(() => computeDraws([], 1)).toThrow(InsufficientStockError);
+	});
+
+	it('attaches requested and available quantities to the error', () => {
+		const lots = [lot(1, 2, 1)];
+
+		try {
+			computeDraws(lots, 5);
+			expect.fail('Expected InsufficientStockError to be thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(InsufficientStockError);
+			expect((error as InsufficientStockError).requested).toBe(5);
+			expect((error as InsufficientStockError).available).toBe(2);
+		}
+	});
+
+	it('handles fractional kilogram quantities to 3 decimal places', () => {
+		const lots = [lot(1, 1.5, 1.25), lot(2, 0.75, 2.5)];
+
+		const draws = computeDraws(lots, 2);
+
+		expect(draws).toEqual([
+			{ lotId: 1, qtyDrawn: 1.5, unitPriceSnapshot: 1.25 },
+			{ lotId: 2, qtyDrawn: 0.5, unitPriceSnapshot: 2.5 },
+		]);
+	});
+
+	it('returns an empty draw list when requested qty is zero', () => {
+		const lots = [lot(1, 10, 1)];
+
+		const draws = computeDraws(lots, 0);
+
+		expect(draws).toEqual([]);
+	});
+});

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -17,6 +17,9 @@ import { FlockService } from '../src/resources/flock/flock.service';
 import { FlockEventService } from '../src/resources/flock-event/flock-event.service';
 import { EggCollectionService } from '../src/resources/egg-collection/egg-collection.service';
 import { WeatherService } from '../src/resources/weather/weather.service';
+import { FeedTypeService } from '../src/resources/feed-type/feed-type.service';
+import { FeedLotService } from '../src/resources/feed-lot/feed-lot.service';
+import { FeedConsumptionService } from '../src/resources/feed-consumption/feed-consumption.service';
 
 declare module 'fastify' {
 	interface FastifyInstance {
@@ -41,6 +44,9 @@ declare module 'fastify' {
 		flockEventService: FlockEventService;
 		eggCollectionService: EggCollectionService;
 		weatherService: WeatherService;
+		feedTypeService: FeedTypeService;
+		feedLotService: FeedLotService;
+		feedConsumptionService: FeedConsumptionService;
 
 		// Helpers
 		handleDbError: (error: unknown, reply: FastifyReply) => void;


### PR DESCRIPTION
## Summary

Phase 1 of the feed inventory feature. Introduces per-flock feed cost tracking with FIFO inventory costing — purchases drain in `purchased_at` order with prices snapshotted at depletion, so backdated edits never rewrite past cost history.

- 4 new tables: `feed_types`, `feed_lots`, `feed_consumptions`, `feed_consumption_lots` (the FIFO snapshot join)
- 3 new resources: `feed-type/`, `feed-lot/`, `feed-consumption/`
- FIFO drain helper with `SELECT ... FOR UPDATE` and consistent lock order (deadlock-free)
- 27 new tests (9 unit + 18 integration). Full suite: **213 passing, zero regressions.**

Phases 2 (feeding schedule + log-todays-feeding) and 3 (financial-transaction integration + cost-by-flock/lot reports) ship in follow-up PRs.

## Key behaviors

- **FIFO with snapshotted price** — once a draw is recorded, its `unit_price_snapshot` never changes
- **Insufficient stock** → `422`, transaction rolls back, no rows created
- **Lot delete with consumption history** → `409` (RESTRICT)
- **Lot price/date edit after partial drain** → `422` (immutable)
- **Backdated lots** do not retroactively rewrite past consumption_lot rows
- **Waste/theft** allowed without a flock (`reason='waste'`); `feeding` requires a flock (CHECK constraint)
- **kg-only** in v1, **single farm currency** in v1
- All routes scoped to the current farm via the existing cookie auth

---

## Frontend integration

All routes live under `/api/v1/`, require the auth cookie, and return the standard envelope:

\`\`\`
{ "status": "success", "message": "...", "data": ..., "meta": { "timestamp": "...", "pagination"?: {...} } }
\`\`\`

Errors:

\`\`\`
{ "status": "error", "message": "...", "meta": { "timestamp": "..." } }
\`\`\`

All IDs in the API are **hashids strings** (e.g. `"k3xQ9aZP"`), not numbers. Quantities and prices are JSON numbers.

### Feed Types — \`/api/v1/feed-types\`

Per-farm catalog of feeds (e.g. "Layer Starter", "Hay", "Grower Pellets").

| Method | Path | Body | Response data | Errors |
|---|---|---|---|---|
| GET | \`/\` | — querystring: \`page\`, \`limit\` | \`FeedType[]\` (paginated) | 400 |
| GET | \`/:id\` | — | \`FeedType\` | 400, 404 |
| POST | \`/\` | \`FeedTypeCreate\` | \`FeedType\` | 400, 409 (duplicate name) |
| PUT | \`/:id\` | \`FeedTypeUpdate\` | \`FeedType\` | 400, 404 |
| DELETE | \`/:id\` | — | \`null\` | 400, 404, 409 (has lots/consumption) |

**\`FeedTypeCreate\`**
\`\`\`
{ "name": "Layer Starter", "notes": "20% protein" }
\`\`\`

**\`FeedTypeUpdate\`** — same fields, all optional.

**\`FeedType\` (response)**
\`\`\`
{
  "id": "k3xQ9aZP",
  "farmId": "abc12345",
  "name": "Layer Starter",
  "notes": "20% protein" | null,
  "createdAt": "2026-04-14T12:00:00.000Z",
  "updatedAt": "2026-04-14T12:00:00.000Z"
}
\`\`\`

---

### Feed Lots — \`/api/v1/feed-lots\`

A purchase batch. \`qtyRemaining\` starts equal to \`qtyPurchased\` and is drained by FIFO when consumptions are recorded.

| Method | Path | Body | Response data | Errors |
|---|---|---|---|---|
| GET | \`/\` | — querystring: \`feedTypeId\`, \`hasStock\` (bool), \`page\`, \`limit\` | \`FeedLot[]\` (paginated) | 400 |
| GET | \`/:id\` | — | \`FeedLot\` | 400, 404 |
| POST | \`/\` | \`FeedLotCreate\` | \`FeedLot\` | 400, 404 |
| PUT | \`/:id\` | \`FeedLotUpdate\` | \`FeedLot\` | 400, 404, **422** (price/date frozen) |
| DELETE | \`/:id\` | — | \`null\` | 400, 404, **409** (has consumption history) |

**\`FeedLotCreate\`**
\`\`\`
{
  "feedTypeId": "k3xQ9aZP",
  "qtyPurchased": 25.0,
  "unitPrice": 1.5,
  "purchasedAt": "2026-04-14",
  "supplier": "Acme Feeds" | undefined,
  "notes": "..." | undefined
}
\`\`\`

**\`FeedLotUpdate\`** — all optional. \`unitPrice\` and \`purchasedAt\` can ONLY be edited while \`qtyRemaining === qtyPurchased\` (untouched). Once any consumption has drained from this lot, attempting to edit them returns **422**. \`supplier\` and \`notes\` are always editable.

\`\`\`
{
  "unitPrice": 1.75,
  "purchasedAt": "2026-04-15",
  "supplier": "Acme Feeds",
  "notes": "Adjusted invoice"
}
\`\`\`

**\`FeedLot\` (response)**
\`\`\`
{
  "id": "lot00abc",
  "farmId": "abc12345",
  "feedTypeId": "k3xQ9aZP",
  "qtyPurchased": 25.0,
  "qtyRemaining": 18.5,
  "unitPrice": 1.5,
  "purchasedAt": "2026-04-14",
  "supplier": "Acme Feeds" | null,
  "notes": "..." | null,
  "createdBy": "user1234",
  "createdAt": "2026-04-14T12:00:00.000Z",
  "updatedAt": "2026-04-14T12:00:00.000Z"
}
\`\`\`

**Delete behavior** — once any \`feed_consumption_lot\` row references this lot, DELETE returns 409 with message *"This feed lot has consumption history and cannot be deleted"*. The frontend should hide/disable the delete button when \`qtyRemaining < qtyPurchased\`.

---

### Feed Consumptions — \`/api/v1/feed-consumptions\`

A single consumption event (feeding, waste, transfer, adjustment). Creating one runs FIFO drain against active lots of the same feed type.

| Method | Path | Body | Response data | Errors |
|---|---|---|---|---|
| GET | \`/\` | — querystring: \`flockId\`, \`feedTypeId\`, \`from\`, \`to\`, \`include=lots\`, \`page\`, \`limit\` | \`FeedConsumption[]\` (paginated) | 400 |
| GET | \`/:id\` | — | \`FeedConsumption\` (lots always included) | 400, 404 |
| POST | \`/\` | \`FeedConsumptionCreate\` | \`FeedConsumption\` (lots included) | 400, 404, **422** (insufficient stock) |
| DELETE | \`/:id\` | — | \`null\` (also restores \`qtyRemaining\` on drained lots) | 400, 404 |

**\`FeedConsumptionCreate\`**
\`\`\`
{
  "flockId": "flock123" | null,        // required when reason='feeding'
  "feedTypeId": "k3xQ9aZP",
  "consumedAt": "2026-04-14",
  "qty": 1.5,
  "reason": "feeding" | "waste" | "transfer" | "adjustment",
  "notes": "..." | undefined
}
\`\`\`

Validation:
- \`reason: 'feeding'\` requires a \`flockId\`. Otherwise → 400.
- \`reason: 'waste'\` or \`'adjustment'\` may have a null \`flockId\`.
- If total available stock for that feed type < \`qty\`, the request fails with **422** and **no rows are created** (the whole transaction rolls back).

**\`FeedConsumption\` (response)**
\`\`\`
{
  "id": "cons5678",
  "farmId": "abc12345",
  "flockId": "flock123" | null,
  "feedTypeId": "k3xQ9aZP",
  "consumedAt": "2026-04-14",
  "qty": 1.5,
  "reason": "feeding",
  "notes": "..." | null,
  "createdBy": "user1234",
  "totalCost": 2.25,                    // sum(qtyDrawn * unitPriceSnapshot) — derived
  "lots": [
    {
      "id": "link999",
      "lotId": "lot00abc",
      "qtyDrawn": 1.0,
      "unitPriceSnapshot": 1.5
    },
    {
      "id": "link1000",
      "lotId": "lot00def",
      "qtyDrawn": 0.5,
      "unitPriceSnapshot": 2.0
    }
  ],
  "createdAt": "2026-04-14T12:00:00.000Z",
  "updatedAt": "2026-04-14T12:00:00.000Z"
}
\`\`\`

\`lots\` is the FIFO breakdown showing which purchase batches the qty was drawn from and the snapshotted price. \`totalCost\` is computed by the serializer; the frontend can display it directly.

**List endpoint:** lots are only included when \`?include=lots\` is passed. Without it, items in the list omit the \`lots\` array (\`totalCost\` will be 0 in that case).

---

### Status code summary

| Code | When |
|---|---|
| 200 | Success |
| 400 | Invalid input, missing required field, invalid hashid, business validation (e.g. feeding without flock) |
| 401 | Not authenticated |
| 404 | Resource not found / not on current farm |
| 409 | Cannot delete because of related rows (lot has consumptions, feed type has lots) |
| 422 | Business rule violation: insufficient stock, lot price/date frozen after partial drain |

---

## Test plan

- [x] All 27 new tests pass (9 unit + 18 integration)
- [x] Full suite green (213/213, no regressions)
- [x] FIFO ordering, cross-lot drain, partial fills
- [x] 422 rejection on insufficient stock — verified rollback (no consumption row, lot qty unchanged)
- [x] Lot delete blocked by FK RESTRICT (409)
- [x] Price freeze on partially consumed lot (422)
- [x] Backdated lot does not rewrite past consumption_lot snapshots
- [x] Consumption delete reverses the drain and restores \`qtyRemaining\`
- [x] CHECK constraint: feeding requires a flock
- [ ] Manual smoke via Bruno (\`little-sheep/\`): create feed_type → create two lots at different prices → create consumption draining across both → verify \`lots\` array and \`totalCost\` → attempt to delete first lot (expect 409) → attempt to over-consume (expect 422)