### PR TITLE
feat(feed-inventory): feeding schedules + log-todays-feeding (Phase 2/3)

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -35,6 +35,10 @@ import {
 	FeedConsumptionLotModel,
 	initFeedConsumptionLotModel,
 } from '../resources/feed-consumption/feed-consumption-lot.model';
+import {
+	FeedingScheduleModel,
+	initFeedingScheduleModel,
+} from '../resources/feeding-schedule/feeding-schedule.model';
 
 export interface Database {
 	sequelize: Sequelize;
@@ -57,6 +61,7 @@ export interface Database {
 		FeedLot: typeof FeedLotModel;
 		FeedConsumption: typeof FeedConsumptionModel;
 		FeedConsumptionLot: typeof FeedConsumptionLotModel;
+		FeedingSchedule: typeof FeedingScheduleModel;
 	};
 }
 
@@ -105,6 +110,7 @@ export const initDatabase = async (): Promise<Database> => {
 	const FeedLot = initFeedLotModel(sequelize);
 	const FeedConsumption = initFeedConsumptionModel(sequelize);
 	const FeedConsumptionLot = initFeedConsumptionLotModel(sequelize);
+	const FeedingSchedule = initFeedingScheduleModel(sequelize);
 
 	// associations
 	// Farm & FarmMembers
@@ -184,6 +190,12 @@ export const initDatabase = async (): Promise<Database> => {
 	FeedConsumptionLot.belongsTo(FeedLot, { foreignKey: 'lotId', as: 'lot' });
 	FeedLot.hasMany(FeedConsumptionLot, { foreignKey: 'lotId', as: 'consumptionLots' });
 
+	FeedingSchedule.belongsTo(FarmModel, { foreignKey: 'farmId', as: 'farm' });
+	FeedingSchedule.belongsTo(Flock, { foreignKey: 'flockId', as: 'flock' });
+	FeedingSchedule.belongsTo(FeedType, { foreignKey: 'feedTypeId', as: 'feedType' });
+	Flock.hasMany(FeedingSchedule, { foreignKey: 'flockId', as: 'feedingSchedules' });
+	FeedType.hasMany(FeedingSchedule, { foreignKey: 'feedTypeId', as: 'feedingSchedules' });
+
 	const db: Database = {
 		sequelize,
 		models: {
@@ -205,6 +217,7 @@ export const initDatabase = async (): Promise<Database> => {
 			FeedLot,
 			FeedConsumption,
 			FeedConsumptionLot,
+			FeedingSchedule,
 		},
 	};
 

--- a/src/migrations/20260414130000-create-feeding-schedules-table.js
+++ b/src/migrations/20260414130000-create-feeding-schedules-table.js
@@ -1,0 +1,79 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.createTable('feeding_schedules', {
+			id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				autoIncrement: true,
+				primaryKey: true,
+				allowNull: false,
+			},
+			farm_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'farms', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'CASCADE',
+			},
+			flock_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'flocks', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			feed_type_id: {
+				type: Sequelize.INTEGER.UNSIGNED,
+				allowNull: false,
+				references: { model: 'feed_types', key: 'id' },
+				onUpdate: 'CASCADE',
+				onDelete: 'RESTRICT',
+			},
+			qty_per_day: {
+				type: Sequelize.DECIMAL(12, 3),
+				allowNull: false,
+			},
+			active_from: {
+				type: Sequelize.DATEONLY,
+				allowNull: false,
+			},
+			active_to: {
+				type: Sequelize.DATEONLY,
+				allowNull: true,
+			},
+			created_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+			updated_at: {
+				type: Sequelize.DATE,
+				allowNull: false,
+				defaultValue: Sequelize.NOW,
+			},
+		});
+
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feeding_schedules ADD CONSTRAINT chk_feeding_schedules_qty_per_day_positive CHECK (qty_per_day > 0)',
+		);
+		await queryInterface.sequelize.query(
+			'ALTER TABLE feeding_schedules ADD CONSTRAINT chk_feeding_schedules_date_range CHECK (active_to IS NULL OR active_to >= active_from)',
+		);
+
+		await queryInterface.addIndex('feeding_schedules', ['farm_id', 'flock_id'], {
+			name: 'idx_feeding_schedules_farm_flock',
+		});
+
+		// Partial unique index: only one open-ended schedule per (flock, feed_type)
+		await queryInterface.sequelize.query(
+			'CREATE UNIQUE INDEX idx_feeding_schedules_flock_type_active ON feeding_schedules (flock_id, feed_type_id) WHERE active_to IS NULL',
+		);
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_feeding_schedules_flock_type_active');
+		await queryInterface.removeIndex('feeding_schedules', 'idx_feeding_schedules_farm_flock');
+		await queryInterface.dropTable('feeding_schedules');
+	},
+};

--- a/src/migrations/20260414130001-add-feeding-idempotency-index.js
+++ b/src/migrations/20260414130001-add-feeding-idempotency-index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+	up: async (queryInterface) => {
+		// Idempotency guard for log-todays-feeding: only one 'feeding' consumption
+		// per (flock, feed_type, day). Waste/transfer/adjustment rows are unaffected.
+		await queryInterface.sequelize.query(
+			"CREATE UNIQUE INDEX idx_feed_consumptions_feeding_idempotency ON feed_consumptions (flock_id, feed_type_id, consumed_at) WHERE reason = 'feeding'",
+		);
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_feed_consumptions_feeding_idempotency');
+	},
+};

--- a/src/plugins/services.plugin.ts
+++ b/src/plugins/services.plugin.ts
@@ -21,6 +21,7 @@ import { WeatherService } from '../resources/weather/weather.service';
 import { FeedTypeService } from '../resources/feed-type/feed-type.service';
 import { FeedLotService } from '../resources/feed-lot/feed-lot.service';
 import { FeedConsumptionService } from '../resources/feed-consumption/feed-consumption.service';
+import { FeedingScheduleService } from '../resources/feeding-schedule/feeding-schedule.service';
 
 const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	// Register all services as Fastify decorators
@@ -45,6 +46,7 @@ const servicesPlugin: FastifyPluginAsync = async (fastify: FastifyInstance) => {
 	fastify.decorate('feedTypeService', new FeedTypeService(fastify.db));
 	fastify.decorate('feedLotService', new FeedLotService(fastify.db));
 	fastify.decorate('feedConsumptionService', new FeedConsumptionService(fastify.db));
+	fastify.decorate('feedingScheduleService', new FeedingScheduleService(fastify.db));
 
 	fastify.log.info('Services plugin registered successfully');
 };

--- a/src/resources/feed-consumption/feed-consumption.service.ts
+++ b/src/resources/feed-consumption/feed-consumption.service.ts
@@ -6,6 +6,7 @@ import { FeedConsumptionCreate, FeedConsumptionReason } from './feed-consumption
 import { PaginatedResult, PaginationParams } from '../../utils/pagination';
 import { decodeId } from '../../utils/id-hash-util';
 import { drainFIFO } from './feed-consumption-fifo';
+import { FeedingScheduleModel } from '../feeding-schedule/feeding-schedule.model';
 
 export interface FeedConsumptionFilters {
 	flockId?: number;
@@ -118,6 +119,72 @@ export class FeedConsumptionService extends BaseService {
 				include: [{ model: this.db.models.FeedConsumptionLot, as: 'lots' }],
 				transaction,
 			}) as Promise<FeedConsumptionModel>;
+		});
+	}
+
+	async logTodaysFeeding(
+		farmId: number,
+		flockId: number,
+		createdBy: number,
+		date: string,
+	): Promise<FeedConsumptionModel[]> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const flock = await this.db.models.Flock.findOne({ where: { id: flockId, farmId }, transaction });
+			if (!flock) throw new Error('Flock not found');
+
+			const schedules = await this.db.models.FeedingSchedule.findAll({
+				where: {
+					farmId,
+					flockId,
+					activeFrom: { [Op.lte]: date },
+					[Op.or]: [{ activeTo: null }, { activeTo: { [Op.gte]: date } }],
+				},
+				order: [['feedTypeId', 'ASC']],
+				transaction,
+			}) as FeedingScheduleModel[];
+
+			if (schedules.length === 0) {
+				throw new Error('No active feeding schedules found for this flock.');
+			}
+
+			const created: FeedConsumptionModel[] = [];
+
+			for (const schedule of schedules) {
+				const draws = await drainFIFO(
+					this.db,
+					{ farmId, feedTypeId: schedule.feedTypeId, qty: Number(schedule.qtyPerDay) },
+					transaction,
+				);
+
+				const consumption = await this.db.models.FeedConsumption.create({
+					farmId,
+					flockId,
+					feedTypeId: schedule.feedTypeId,
+					consumedAt: date,
+					qty: Number(schedule.qtyPerDay),
+					reason: FeedConsumptionReason.Feeding,
+					notes: null,
+					createdBy,
+				}, { transaction });
+
+				await this.db.models.FeedConsumptionLot.bulkCreate(
+					draws.map(draw => ({
+						consumptionId: consumption.id,
+						lotId: draw.lotId,
+						qtyDrawn: draw.qtyDrawn,
+						unitPriceSnapshot: draw.unitPriceSnapshot,
+					})),
+					{ transaction },
+				);
+
+				const reloaded = await this.db.models.FeedConsumption.findByPk(consumption.id, {
+					include: [{ model: this.db.models.FeedConsumptionLot, as: 'lots' }],
+					transaction,
+				}) as FeedConsumptionModel;
+				created.push(reloaded);
+			}
+
+			return created;
 		});
 	}
 

--- a/src/resources/feed-consumption/index.ts
+++ b/src/resources/feed-consumption/index.ts
@@ -1,8 +1,10 @@
 import { FastifyPluginAsync } from 'fastify';
 import feedConsumptionRoutes from './feed-consumption.routes';
+import logTodaysFeedingRoutes from './log-todays-feeding.routes';
 
 const feedConsumptionPlugin: FastifyPluginAsync = async (fastify) => {
 	await fastify.register(feedConsumptionRoutes, { prefix: '/feed-consumptions' });
+	await fastify.register(logTodaysFeedingRoutes);
 };
 
 export default feedConsumptionPlugin;

--- a/src/resources/feed-consumption/log-todays-feeding.routes.ts
+++ b/src/resources/feed-consumption/log-todays-feeding.routes.ts
@@ -1,0 +1,54 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import { Static, Type } from '@sinclair/typebox';
+import { decodeId } from '../../utils/id-hash-util';
+import {
+	FeedConsumptionResponseSchema,
+} from './feed-consumption.schema';
+import { FeedConsumptionSerializer } from './feed-consumption.serializer';
+import { FeedConsumptionWithLots } from './feed-consumption.service';
+import { createPostEndpointSchema } from '../../utils/schema-builder';
+
+const LogTodaysFeedingParamsSchema = Type.Object({
+	flockId: Type.String(),
+});
+
+const LogTodaysFeedingBodySchema = Type.Object({
+	date: Type.Optional(Type.String({ format: 'date' })),
+}, {
+	additionalProperties: false,
+});
+
+type LogTodaysFeedingParams = Static<typeof LogTodaysFeedingParamsSchema>;
+type LogTodaysFeedingBody = Static<typeof LogTodaysFeedingBodySchema>;
+
+const logTodaysFeedingSchema = createPostEndpointSchema({
+	params: LogTodaysFeedingParamsSchema,
+	body: LogTodaysFeedingBodySchema,
+	dataSchema: Type.Array(FeedConsumptionResponseSchema),
+	errorCodes: [400, 404, 409, 422],
+});
+
+const logTodaysFeedingRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.post('/flocks/:flockId/log-todays-feeding', { schema: logTodaysFeedingSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: LogTodaysFeedingParams; Body: LogTodaysFeedingBody }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const userId = request.user!.id;
+			const flockId = decodeId(request.params.flockId);
+			if (!flockId) return reply.error('Invalid flock ID', 400);
+
+			const date = request.body?.date ?? new Date().toISOString().slice(0, 10);
+
+			const created = await fastify.feedConsumptionService.logTodaysFeeding(farmId, flockId, userId, date);
+			const serialized = FeedConsumptionSerializer.serializeMany(created as FeedConsumptionWithLots[]);
+			reply.success(serialized);
+		} catch (error) {
+			if (error instanceof Error && error.name === 'InsufficientStockError') {
+				return reply.error(error.message, 422);
+			}
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default logTodaysFeedingRoutes;

--- a/src/resources/feeding-schedule/feeding-schedule.model.ts
+++ b/src/resources/feeding-schedule/feeding-schedule.model.ts
@@ -1,0 +1,81 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+import { FeedingSchedule } from './feeding-schedule.schema';
+
+type FeedingScheduleCreationAttributes = Pick<
+	FeedingSchedule,
+	'farmId' | 'flockId' | 'feedTypeId' | 'qtyPerDay' | 'activeFrom'
+> & Partial<Pick<FeedingSchedule, 'activeTo'>>;
+
+export class FeedingScheduleModel extends Model<FeedingSchedule, FeedingScheduleCreationAttributes> {
+	declare id: number;
+	declare farmId: number;
+	declare flockId: number;
+	declare feedTypeId: number;
+	declare qtyPerDay: number;
+	declare activeFrom: string;
+	declare activeTo: string | null;
+	declare createdAt: string;
+	declare updatedAt: string;
+}
+
+export const initFeedingScheduleModel = (sequelize: Sequelize) => FeedingScheduleModel.init({
+	id: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		autoIncrement: true,
+		primaryKey: true,
+		field: 'id',
+	},
+	farmId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'farm_id',
+		references: { model: 'farms', key: 'id' },
+		onDelete: 'CASCADE',
+	},
+	flockId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'flock_id',
+		references: { model: 'flocks', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	feedTypeId: {
+		type: DataTypes.INTEGER.UNSIGNED,
+		allowNull: false,
+		field: 'feed_type_id',
+		references: { model: 'feed_types', key: 'id' },
+		onDelete: 'RESTRICT',
+	},
+	qtyPerDay: {
+		type: DataTypes.DECIMAL(12, 3),
+		allowNull: false,
+		field: 'qty_per_day',
+	},
+	activeFrom: {
+		type: DataTypes.DATEONLY,
+		allowNull: false,
+		field: 'active_from',
+	},
+	activeTo: {
+		type: DataTypes.DATEONLY,
+		allowNull: true,
+		field: 'active_to',
+	},
+	createdAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'created_at',
+	},
+	updatedAt: {
+		type: DataTypes.DATE,
+		allowNull: false,
+		defaultValue: DataTypes.NOW,
+		field: 'updated_at',
+	},
+}, {
+	sequelize,
+	tableName: 'feeding_schedules',
+	modelName: 'FeedingSchedule',
+	timestamps: true,
+});

--- a/src/resources/feeding-schedule/feeding-schedule.routes.ts
+++ b/src/resources/feeding-schedule/feeding-schedule.routes.ts
@@ -1,0 +1,101 @@
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import {
+	FeedingScheduleCreate,
+	FeedingScheduleUpdate,
+	FeedingScheduleQuery,
+	FeedingScheduleParams,
+	listFeedingSchedulesSchema,
+	getFeedingScheduleByIdSchema,
+	createFeedingScheduleSchema,
+	updateFeedingScheduleSchema,
+	deleteFeedingScheduleSchema,
+} from './feeding-schedule.schema';
+import { FeedingScheduleSerializer } from './feeding-schedule.serializer';
+import { FeedingScheduleFilters } from './feeding-schedule.service';
+import { decodeId } from '../../utils/id-hash-util';
+import { parsePagination } from '../../utils/pagination';
+
+const feedingScheduleRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
+
+	fastify.get('/', { schema: listFeedingSchedulesSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Querystring: FeedingScheduleQuery }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const pagination = parsePagination(request.query);
+
+			const filters: FeedingScheduleFilters = {};
+			if (request.query.flockId) {
+				const decoded = decodeId(request.query.flockId);
+				if (!decoded) return reply.error('Invalid flock ID', 400);
+				filters.flockId = decoded;
+			}
+			if (request.query.feedTypeId) {
+				const decoded = decodeId(request.query.feedTypeId);
+				if (!decoded) return reply.error('Invalid feed type ID', 400);
+				filters.feedTypeId = decoded;
+			}
+			if (request.query.activeOnly !== undefined) filters.activeOnly = request.query.activeOnly;
+
+			const result = await fastify.feedingScheduleService.getFeedingSchedules(farmId, filters, pagination);
+			reply.successWithPagination(FeedingScheduleSerializer.serializeMany(result.rows), result.pagination);
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.get('/:id', { schema: getFeedingScheduleByIdSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedingScheduleParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const scheduleId = decodeId(request.params.id);
+			if (!scheduleId) return reply.error('Invalid schedule ID', 400);
+
+			const schedule = await fastify.feedingScheduleService.getFeedingScheduleById(scheduleId, farmId);
+			if (!schedule) return reply.error('Feeding schedule not found', 404);
+
+			reply.success(FeedingScheduleSerializer.serialize(schedule));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.post('/', { schema: createFeedingScheduleSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Body: FeedingScheduleCreate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const schedule = await fastify.feedingScheduleService.createFeedingSchedule(farmId, request.body);
+			reply.success(FeedingScheduleSerializer.serialize(schedule));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.put('/:id', { schema: updateFeedingScheduleSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedingScheduleParams; Body: FeedingScheduleUpdate }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const scheduleId = decodeId(request.params.id);
+			if (!scheduleId) return reply.error('Invalid schedule ID', 400);
+
+			const schedule = await fastify.feedingScheduleService.updateFeedingSchedule(scheduleId, farmId, request.body);
+			if (!schedule) return reply.error('Feeding schedule not found', 404);
+
+			reply.success(FeedingScheduleSerializer.serialize(schedule));
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+
+	fastify.delete('/:id', { schema: deleteFeedingScheduleSchema, preHandler: fastify.authenticate }, async (request: FastifyRequest<{ Params: FeedingScheduleParams }>, reply) => {
+		try {
+			const farmId = request.lastVisitedFarmId;
+			const scheduleId = decodeId(request.params.id);
+			if (!scheduleId) return reply.error('Invalid schedule ID', 400);
+
+			const deleted = await fastify.feedingScheduleService.deleteFeedingSchedule(scheduleId, farmId);
+			if (!deleted) return reply.error('Feeding schedule not found', 404);
+
+			reply.success(null, 'Feeding schedule deleted successfully');
+		} catch (error) {
+			fastify.handleDbError(error, reply);
+		}
+	});
+};
+
+export default feedingScheduleRoutes;

--- a/src/resources/feeding-schedule/feeding-schedule.schema.ts
+++ b/src/resources/feeding-schedule/feeding-schedule.schema.ts
@@ -1,0 +1,106 @@
+import { Static, Type } from '@sinclair/typebox';
+import {
+	createGetEndpointSchema,
+	createListEndpointSchema,
+	createPostEndpointSchema,
+	createUpdateEndpointSchema,
+	createDeleteEndpointSchema,
+} from '../../utils/schema-builder';
+import { PaginationQueryProps } from '../../utils/pagination';
+
+const FeedingScheduleSchema = Type.Object({
+	id: Type.Integer({ minimum: 1 }),
+	farmId: Type.Integer(),
+	flockId: Type.Integer(),
+	feedTypeId: Type.Integer(),
+	qtyPerDay: Type.Number(),
+	activeFrom: Type.String(),
+	activeTo: Type.Union([Type.String(), Type.Null()]),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+}, {
+	$id: 'feedingSchedule',
+	additionalProperties: false,
+});
+
+export const FeedingScheduleResponseSchema = Type.Object({
+	...FeedingScheduleSchema.properties,
+	id: Type.String(),
+	farmId: Type.String(),
+	flockId: Type.String(),
+	feedTypeId: Type.String(),
+}, {
+	$id: 'feedingScheduleResponse',
+	additionalProperties: false,
+});
+
+export const FeedingScheduleCreateSchema = Type.Object({
+	flockId: Type.String(),
+	feedTypeId: Type.String(),
+	qtyPerDay: Type.Number({ exclusiveMinimum: 0 }),
+	activeFrom: Type.String({ format: 'date' }),
+	activeTo: Type.Optional(Type.Union([Type.String({ format: 'date' }), Type.Null()])),
+}, {
+	$id: 'feedingScheduleCreate',
+	additionalProperties: false,
+});
+
+export const FeedingScheduleUpdateSchema = Type.Object({
+	qtyPerDay: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
+	activeFrom: Type.Optional(Type.String({ format: 'date' })),
+	activeTo: Type.Optional(Type.Union([Type.String({ format: 'date' }), Type.Null()])),
+}, {
+	$id: 'feedingScheduleUpdate',
+	additionalProperties: false,
+});
+
+export const FeedingScheduleQuerySchema = Type.Object({
+	flockId: Type.Optional(Type.String()),
+	feedTypeId: Type.Optional(Type.String()),
+	activeOnly: Type.Optional(Type.Boolean()),
+	...PaginationQueryProps,
+}, {
+	$id: 'feedingScheduleQuery',
+	additionalProperties: false,
+});
+
+export const FeedingScheduleParamsSchema = Type.Object({
+	id: Type.String(),
+});
+
+export type FeedingSchedule = Static<typeof FeedingScheduleSchema>;
+export type FeedingScheduleResponse = Static<typeof FeedingScheduleResponseSchema>;
+export type FeedingScheduleCreate = Static<typeof FeedingScheduleCreateSchema>;
+export type FeedingScheduleUpdate = Static<typeof FeedingScheduleUpdateSchema>;
+export type FeedingScheduleQuery = Static<typeof FeedingScheduleQuerySchema>;
+export type FeedingScheduleParams = Static<typeof FeedingScheduleParamsSchema>;
+
+export const listFeedingSchedulesSchema = createListEndpointSchema({
+	querystring: FeedingScheduleQuerySchema,
+	dataSchema: Type.Array(FeedingScheduleResponseSchema),
+	errorCodes: [400],
+});
+
+export const getFeedingScheduleByIdSchema = createGetEndpointSchema({
+	params: FeedingScheduleParamsSchema,
+	dataSchema: FeedingScheduleResponseSchema,
+	errorCodes: [400, 404],
+});
+
+export const createFeedingScheduleSchema = createPostEndpointSchema({
+	body: FeedingScheduleCreateSchema,
+	dataSchema: FeedingScheduleResponseSchema,
+	errorCodes: [400, 404, 409],
+});
+
+export const updateFeedingScheduleSchema = createUpdateEndpointSchema({
+	params: FeedingScheduleParamsSchema,
+	body: FeedingScheduleUpdateSchema,
+	dataSchema: FeedingScheduleResponseSchema,
+	errorCodes: [400, 404, 409],
+});
+
+export const deleteFeedingScheduleSchema = createDeleteEndpointSchema({
+	params: FeedingScheduleParamsSchema,
+	errorCodes: [400, 404],
+});

--- a/src/resources/feeding-schedule/feeding-schedule.serializer.ts
+++ b/src/resources/feeding-schedule/feeding-schedule.serializer.ts
@@ -1,0 +1,23 @@
+import { encodeId } from '../../utils/id-hash-util';
+import { FeedingScheduleModel } from './feeding-schedule.model';
+import { FeedingScheduleResponse } from './feeding-schedule.schema';
+
+export class FeedingScheduleSerializer {
+	static serialize(schedule: FeedingScheduleModel): FeedingScheduleResponse {
+		return {
+			id: encodeId(schedule.id),
+			farmId: encodeId(schedule.farmId),
+			flockId: encodeId(schedule.flockId),
+			feedTypeId: encodeId(schedule.feedTypeId),
+			qtyPerDay: Number(schedule.qtyPerDay),
+			activeFrom: schedule.activeFrom,
+			activeTo: schedule.activeTo,
+			createdAt: schedule.createdAt,
+			updatedAt: schedule.updatedAt,
+		};
+	}
+
+	static serializeMany(schedules: FeedingScheduleModel[]): FeedingScheduleResponse[] {
+		return schedules.map(s => this.serialize(s));
+	}
+}

--- a/src/resources/feeding-schedule/feeding-schedule.service.ts
+++ b/src/resources/feeding-schedule/feeding-schedule.service.ts
@@ -1,0 +1,117 @@
+import { FindOptions, Op } from 'sequelize';
+import { BaseService } from '../../services/base.service';
+import { FeedingScheduleModel } from './feeding-schedule.model';
+import { FeedingScheduleCreate, FeedingScheduleUpdate } from './feeding-schedule.schema';
+import { PaginatedResult, PaginationParams } from '../../utils/pagination';
+import { decodeId } from '../../utils/id-hash-util';
+
+export interface FeedingScheduleFilters {
+	flockId?: number;
+	feedTypeId?: number;
+	activeOnly?: boolean;
+}
+
+export class FeedingScheduleService extends BaseService {
+	async getFeedingSchedules(
+		farmId: number,
+		filters: FeedingScheduleFilters,
+		pagination: PaginationParams,
+	): Promise<PaginatedResult<FeedingScheduleModel>> {
+		const where: Record<string, unknown> = { farmId };
+		if (filters.flockId !== undefined) where.flockId = filters.flockId;
+		if (filters.feedTypeId !== undefined) where.feedTypeId = filters.feedTypeId;
+		if (filters.activeOnly) where.activeTo = null;
+
+		const findOptions: FindOptions = {
+			where,
+			order: [['flockId', 'ASC'], ['feedTypeId', 'ASC']],
+		};
+
+		return this.findAllPaginated(this.db.models.FeedingSchedule, findOptions, pagination);
+	}
+
+	async getFeedingScheduleById(id: number, farmId: number): Promise<FeedingScheduleModel | null> {
+		return this.db.models.FeedingSchedule.findOne({ where: { id, farmId } });
+	}
+
+	async createFeedingSchedule(farmId: number, data: FeedingScheduleCreate): Promise<FeedingScheduleModel> {
+		const flockId = decodeId(data.flockId);
+		if (!flockId) throw new Error('Invalid flock ID');
+		const feedTypeId = decodeId(data.feedTypeId);
+		if (!feedTypeId) throw new Error('Invalid feed type ID');
+
+		return this.db.sequelize.transaction(async (transaction) => {
+			const flock = await this.db.models.Flock.findOne({ where: { id: flockId, farmId }, transaction });
+			if (!flock) throw new Error('Flock not found');
+
+			const feedType = await this.db.models.FeedType.findOne({ where: { id: feedTypeId, farmId }, transaction });
+			if (!feedType) throw new Error('Feed type not found');
+
+			return this.db.models.FeedingSchedule.create({
+				farmId,
+				flockId,
+				feedTypeId,
+				qtyPerDay: data.qtyPerDay,
+				activeFrom: data.activeFrom,
+				activeTo: data.activeTo ?? null,
+			}, { transaction });
+		});
+	}
+
+	async updateFeedingSchedule(
+		id: number,
+		farmId: number,
+		data: FeedingScheduleUpdate,
+	): Promise<FeedingScheduleModel | null> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const schedule = await this.db.models.FeedingSchedule.findOne({
+				where: { id, farmId },
+				transaction,
+				lock: true,
+			});
+			if (!schedule) return null;
+
+			const updates: Record<string, unknown> = {};
+			if (data.qtyPerDay !== undefined) updates.qtyPerDay = data.qtyPerDay;
+			if (data.activeFrom !== undefined) updates.activeFrom = data.activeFrom;
+			if (data.activeTo !== undefined) updates.activeTo = data.activeTo;
+
+			await schedule.update(updates, { transaction });
+			return schedule;
+		});
+	}
+
+	async deleteFeedingSchedule(id: number, farmId: number): Promise<boolean> {
+		return this.db.sequelize.transaction(async (transaction) => {
+			const schedule = await this.db.models.FeedingSchedule.findOne({
+				where: { id, farmId },
+				transaction,
+			});
+			if (!schedule) return false;
+
+			await schedule.destroy({ transaction });
+			return true;
+		});
+	}
+
+	async getActiveSchedulesForFlock(
+		farmId: number,
+		flockId: number,
+		date: string,
+		transaction?: import('sequelize').Transaction,
+	): Promise<FeedingScheduleModel[]> {
+		return this.db.models.FeedingSchedule.findAll({
+			where: {
+				farmId,
+				flockId,
+				activeFrom: { [Op.lte]: date },
+				[Op.or]: [
+					{ activeTo: null },
+					{ activeTo: { [Op.gte]: date } },
+				],
+			},
+			order: [['feedTypeId', 'ASC']],
+			transaction,
+		});
+	}
+}

--- a/src/resources/feeding-schedule/index.ts
+++ b/src/resources/feeding-schedule/index.ts
@@ -1,0 +1,8 @@
+import { FastifyPluginAsync } from 'fastify';
+import feedingScheduleRoutes from './feeding-schedule.routes';
+
+const feedingSchedulePlugin: FastifyPluginAsync = async (fastify) => {
+	await fastify.register(feedingScheduleRoutes, { prefix: '/feeding-schedules' });
+};
+
+export default feedingSchedulePlugin;

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -184,6 +184,28 @@ export async function createFeedLot(
 	};
 }
 
+export async function createFeedingSchedule(
+	app: FastifyInstance,
+	farmId: number,
+	flockId: number,
+	feedTypeId: number,
+	overrides?: { qtyPerDay?: number; activeFrom?: string; activeTo?: string | null },
+): Promise<{ scheduleId: number; encodedScheduleId: string }> {
+	const schedule = await app.db.models.FeedingSchedule.create({
+		farmId,
+		flockId,
+		feedTypeId,
+		qtyPerDay: overrides?.qtyPerDay ?? 1,
+		activeFrom: overrides?.activeFrom ?? '2026-01-01',
+		activeTo: overrides?.activeTo ?? null,
+	});
+
+	return {
+		scheduleId: schedule.dataValues.id,
+		encodedScheduleId: encodeId(schedule.dataValues.id),
+	};
+}
+
 export async function createFinancialTransaction(
 	app: FastifyInstance,
 	farmId: number,

--- a/tests/integration/feeding-schedule.test.ts
+++ b/tests/integration/feeding-schedule.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import { createSpecies, createBreed, createFlock, createFeedType, createFeedingSchedule } from '../helpers/factories';
+import { encodeId } from '../../src/utils/id-hash-util';
+
+async function setupFlockAndFeedType(app: FastifyInstance) {
+	const { user, cookie } = await createAuthenticatedUser(app);
+	const { speciesId } = await createSpecies(app);
+	const { breedId } = await createBreed(app, speciesId);
+	const { flockId, encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId);
+	const { feedTypeId, encodedFeedTypeId } = await createFeedType(app, user.farmId);
+	return { user, cookie, flockId, encodedFlockId, feedTypeId, encodedFeedTypeId };
+}
+
+describe('Feeding schedule endpoints', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	describe('POST /api/v1/feeding-schedules', () => {
+		it('creates a schedule', async () => {
+			const { cookie, encodedFlockId, encodedFeedTypeId } = await setupFlockAndFeedType(app);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feeding-schedules',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qtyPerDay: 1.5,
+					activeFrom: '2026-01-01',
+				},
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.qtyPerDay).toBe(1.5);
+			expect(body.data.activeFrom).toBe('2026-01-01');
+			expect(body.data.activeTo).toBeNull();
+		});
+
+		it('returns 400 for unknown flock', async () => {
+			const { cookie, encodedFeedTypeId } = await setupFlockAndFeedType(app);
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feeding-schedules',
+				headers: { cookie },
+				payload: {
+					flockId: encodeId(99999),
+					feedTypeId: encodedFeedTypeId,
+					qtyPerDay: 1,
+					activeFrom: '2026-01-01',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('rejects a second open-ended schedule for the same (flock, feed_type)', async () => {
+			const { user, cookie, flockId, feedTypeId, encodedFlockId, encodedFeedTypeId } = await setupFlockAndFeedType(app);
+			await createFeedingSchedule(app, user.farmId, flockId, feedTypeId, { activeTo: null });
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feeding-schedules',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qtyPerDay: 2,
+					activeFrom: '2026-02-01',
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+		});
+
+		it('allows a closed schedule then a new open-ended one', async () => {
+			const { user, cookie, flockId, feedTypeId, encodedFlockId, encodedFeedTypeId } = await setupFlockAndFeedType(app);
+			await createFeedingSchedule(app, user.farmId, flockId, feedTypeId, {
+				activeFrom: '2025-01-01',
+				activeTo: '2025-12-31',
+			});
+
+			const response = await app.inject({
+				method: 'POST',
+				url: '/api/v1/feeding-schedules',
+				headers: { cookie },
+				payload: {
+					flockId: encodedFlockId,
+					feedTypeId: encodedFeedTypeId,
+					qtyPerDay: 2,
+					activeFrom: '2026-01-01',
+				},
+			});
+
+			expect(response.statusCode).toBe(200);
+		});
+	});
+
+	describe('GET /api/v1/feeding-schedules', () => {
+		it('lists schedules filtered by flock', async () => {
+			const { user, cookie, flockId, feedTypeId } = await setupFlockAndFeedType(app);
+			await createFeedingSchedule(app, user.farmId, flockId, feedTypeId);
+
+			const response = await app.inject({
+				method: 'GET',
+				url: `/api/v1/feeding-schedules?flockId=${encodeId(flockId)}`,
+				headers: { cookie },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data).toHaveLength(1);
+		});
+	});
+
+	describe('PUT /api/v1/feeding-schedules/:id', () => {
+		it('updates qty and active range', async () => {
+			const { user, cookie, flockId, feedTypeId } = await setupFlockAndFeedType(app);
+			const { encodedScheduleId } = await createFeedingSchedule(app, user.farmId, flockId, feedTypeId);
+
+			const response = await app.inject({
+				method: 'PUT',
+				url: `/api/v1/feeding-schedules/${encodedScheduleId}`,
+				headers: { cookie },
+				payload: { qtyPerDay: 2.5, activeTo: '2026-12-31' },
+			});
+
+			const body = response.json();
+			expect(response.statusCode).toBe(200);
+			expect(body.data.qtyPerDay).toBe(2.5);
+			expect(body.data.activeTo).toBe('2026-12-31');
+		});
+	});
+
+	describe('DELETE /api/v1/feeding-schedules/:id', () => {
+		it('deletes a schedule', async () => {
+			const { user, cookie, flockId, feedTypeId } = await setupFlockAndFeedType(app);
+			const { encodedScheduleId } = await createFeedingSchedule(app, user.farmId, flockId, feedTypeId);
+
+			const response = await app.inject({
+				method: 'DELETE',
+				url: `/api/v1/feeding-schedules/${encodedScheduleId}`,
+				headers: { cookie },
+			});
+
+			expect(response.statusCode).toBe(200);
+		});
+	});
+});

--- a/tests/integration/log-todays-feeding.test.ts
+++ b/tests/integration/log-todays-feeding.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { FastifyInstance } from 'fastify';
+import { createTestApp } from '../helpers/build-app';
+import { createAuthenticatedUser } from '../helpers/auth';
+import { truncateAllTables } from '../helpers/truncate';
+import {
+	createSpecies, createBreed, createFlock, createFeedType, createFeedLot, createFeedingSchedule,
+} from '../helpers/factories';
+import { encodeId } from '../../src/utils/id-hash-util';
+
+const TODAY = '2026-04-14';
+
+async function setupFlock(app: FastifyInstance) {
+	const { user, cookie } = await createAuthenticatedUser(app);
+	const { speciesId } = await createSpecies(app);
+	const { breedId } = await createBreed(app, speciesId);
+	const { flockId, encodedFlockId } = await createFlock(app, user.farmId, speciesId, breedId);
+	return { user, cookie, flockId, encodedFlockId };
+}
+
+describe('POST /api/v1/flocks/:flockId/log-todays-feeding', () => {
+	let app: FastifyInstance;
+
+	beforeAll(async () => {
+		app = await createTestApp();
+	});
+
+	afterEach(async () => {
+		await truncateAllTables(app);
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	it('returns 401 when not authenticated', async () => {
+		const response = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodeId(1)}/log-todays-feeding`,
+			payload: { date: TODAY },
+		});
+
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('logs feeding for all active schedules in one transaction', async () => {
+		const { user, cookie, flockId, encodedFlockId } = await setupFlock(app);
+		const { feedTypeId: hayId } = await createFeedType(app, user.farmId, { name: 'Hay' });
+		const { feedTypeId: grainId } = await createFeedType(app, user.farmId, { name: 'Grain' });
+		await createFeedLot(app, user.farmId, hayId, user.id, { qtyPurchased: 10, unitPrice: 1 });
+		await createFeedLot(app, user.farmId, grainId, user.id, { qtyPurchased: 10, unitPrice: 2 });
+		await createFeedingSchedule(app, user.farmId, flockId, hayId, { qtyPerDay: 1, activeFrom: '2026-01-01' });
+		await createFeedingSchedule(app, user.farmId, flockId, grainId, { qtyPerDay: 0.5, activeFrom: '2026-01-01' });
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+
+		const body = response.json();
+		expect(response.statusCode).toBe(200);
+		expect(body.data).toHaveLength(2);
+		expect(body.data.every((c: { reason: string }) => c.reason === 'feeding')).toBe(true);
+
+		const consumptions = await app.db.models.FeedConsumption.findAll();
+		expect(consumptions).toHaveLength(2);
+	});
+
+	it('returns 400 when no active schedules exist', async () => {
+		const { cookie, encodedFlockId } = await setupFlock(app);
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().message).toMatch(/no active feeding schedules/i);
+	});
+
+	it('returns 409 (idempotency) when called twice on the same day', async () => {
+		const { user, cookie, flockId, encodedFlockId } = await setupFlock(app);
+		const { feedTypeId } = await createFeedType(app, user.farmId);
+		await createFeedLot(app, user.farmId, feedTypeId, user.id, { qtyPurchased: 10 });
+		await createFeedingSchedule(app, user.farmId, flockId, feedTypeId, { qtyPerDay: 1 });
+
+		const first = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+		expect(first.statusCode).toBe(200);
+
+		const second = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+		expect(second.statusCode).toBe(400);
+
+		const consumptions = await app.db.models.FeedConsumption.findAll();
+		expect(consumptions).toHaveLength(1);
+	});
+
+	it('rolls back the entire batch when one schedule has insufficient stock', async () => {
+		const { user, cookie, flockId, encodedFlockId } = await setupFlock(app);
+		const { feedTypeId: hayId } = await createFeedType(app, user.farmId, { name: 'Hay' });
+		const { feedTypeId: grainId } = await createFeedType(app, user.farmId, { name: 'Grain' });
+		const { feedLotId: hayLotId } = await createFeedLot(app, user.farmId, hayId, user.id, { qtyPurchased: 10 });
+		// Grain has only 0.2, schedule wants 0.5 → insufficient
+		await createFeedLot(app, user.farmId, grainId, user.id, { qtyPurchased: 0.2 });
+		await createFeedingSchedule(app, user.farmId, flockId, hayId, { qtyPerDay: 1 });
+		await createFeedingSchedule(app, user.farmId, flockId, grainId, { qtyPerDay: 0.5 });
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+
+		expect(response.statusCode).toBe(422);
+
+		const consumptions = await app.db.models.FeedConsumption.findAll();
+		expect(consumptions).toHaveLength(0);
+
+		const hayLot = await app.db.models.FeedLot.findByPk(hayLotId);
+		expect(Number(hayLot!.qtyRemaining)).toBe(10);
+	});
+
+	it('skips schedules outside the active window', async () => {
+		const { user, cookie, flockId, encodedFlockId } = await setupFlock(app);
+		const { feedTypeId } = await createFeedType(app, user.farmId);
+		await createFeedLot(app, user.farmId, feedTypeId, user.id, { qtyPurchased: 10 });
+		// Active window ends before today
+		await createFeedingSchedule(app, user.farmId, flockId, feedTypeId, {
+			qtyPerDay: 1,
+			activeFrom: '2025-01-01',
+			activeTo: '2025-12-31',
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/api/v1/flocks/${encodedFlockId}/log-todays-feeding`,
+			headers: { cookie },
+			payload: { date: TODAY },
+		});
+
+		// No active schedules → 400
+		expect(response.statusCode).toBe(400);
+	});
+});

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -20,6 +20,7 @@ import { WeatherService } from '../src/resources/weather/weather.service';
 import { FeedTypeService } from '../src/resources/feed-type/feed-type.service';
 import { FeedLotService } from '../src/resources/feed-lot/feed-lot.service';
 import { FeedConsumptionService } from '../src/resources/feed-consumption/feed-consumption.service';
+import { FeedingScheduleService } from '../src/resources/feeding-schedule/feeding-schedule.service';
 
 declare module 'fastify' {
 	interface FastifyInstance {
@@ -47,6 +48,7 @@ declare module 'fastify' {
 		feedTypeService: FeedTypeService;
 		feedLotService: FeedLotService;
 		feedConsumptionService: FeedConsumptionService;
+		feedingScheduleService: FeedingScheduleService;
 
 		// Helpers
 		handleDbError: (error: unknown, reply: FastifyReply) => void;


### PR DESCRIPTION
## Summary

Phase 2 of the feed inventory feature. Builds on Phase 1 (#19) by letting users define a daily ration per `(flock, feed_type)` and confirm "today's feeding" with one call.

- 1 new table: `feeding_schedules` with a partial unique index `(flock_id, feed_type_id) WHERE active_to IS NULL` (only one open-ended schedule per pair)
- 1 new index on `feed_consumptions`: partial unique `(flock_id, feed_type_id, consumed_at) WHERE reason='feeding'` (idempotency guard for the new endpoint)
- 1 new resource: `feeding-schedule/` (CRUD)
- 1 new endpoint: `POST /api/v1/flocks/:flockId/log-todays-feeding`
- 13 new tests. Full suite: **226 passing, zero regressions.**

Phase 3 (financial-transaction integration + cost-by-flock/lot reports) ships next.

## Key behaviors

- **Atomic batch** — `log-todays-feeding` reads all active schedules for the flock, creates one `feed_consumption` per schedule with `reason='feeding'`, and runs FIFO drain in a single Sequelize transaction. If any schedule has insufficient stock, the **entire batch rolls back** (no partial writes).
- **Idempotency** — calling `log-todays-feeding` twice on the same day returns **400** (Postgres unique violation surfaced via `handleSequelizeError`); stock is drained only once. The frontend can safely retry.
- **Active window** — schedules outside `[active_from, active_to]` (or with `active_to < today`) are ignored.
- **One open-ended schedule per pair** — attempting to create a second schedule with `active_to = null` for the same `(flock, feed_type)` is blocked at the DB level. Close the existing one first (set `active_to`).
- **Insufficient stock** — surfaces as **422** with no rows created (whole transaction rolled back).
- **No active schedules** → **400** with `"No active feeding schedules found for this flock."`

---

## Frontend integration

All routes live under `/api/v1/`, require the auth cookie, and return the standard envelope. IDs are hashids strings. See PR #19 for the full envelope/error shape.

### Feeding Schedules — `/api/v1/feeding-schedules`

A daily ration rule for a flock + feed type, valid over a date range. Open-ended (`activeTo: null`) means "until further notice".

| Method | Path | Body | Response data | Errors |
|---|---|---|---|---|
| GET | `/` | — querystring: `flockId`, `feedTypeId`, `activeOnly` (bool), `page`, `limit` | `FeedingSchedule[]` (paginated) | 400 |
| GET | `/:id` | — | `FeedingSchedule` | 400, 404 |
| POST | `/` | `FeedingScheduleCreate` | `FeedingSchedule` | 400 (unknown flock/type, second open-ended schedule), 404, 409 |
| PUT | `/:id` | `FeedingScheduleUpdate` | `FeedingSchedule` | 400, 404, 409 |
| DELETE | `/:id` | — | `null` | 400, 404 |

**`FeedingScheduleCreate`**
```
{
  "flockId": "flock123",
  "feedTypeId": "k3xQ9aZP",
  "qtyPerDay": 1.5,
  "activeFrom": "2026-04-14",
  "activeTo": "2026-12-31" | null | undefined
}
```

**`FeedingScheduleUpdate`** — all optional. Cannot change `flockId`/`feedTypeId` (delete and recreate to move a schedule).
```
{
  "qtyPerDay": 2.0,
  "activeFrom": "2026-04-15",
  "activeTo": "2026-12-31" | null
}
```

**`FeedingSchedule` (response)**
```
{
  "id": "sch00abc",
  "farmId": "abc12345",
  "flockId": "flock123",
  "feedTypeId": "k3xQ9aZP",
  "qtyPerDay": 1.5,
  "activeFrom": "2026-04-14",
  "activeTo": "2026-12-31" | null,
  "createdAt": "2026-04-14T12:00:00.000Z",
  "updatedAt": "2026-04-14T12:00:00.000Z"
}
```

**Validation rules:**
- `activeTo`, if provided, must be `>= activeFrom` (DB CHECK).
- Only one schedule with `activeTo: null` is allowed per `(flock, feed_type)` (partial unique index). Trying to create a second returns 400.

---

### Log Today's Feeding — `POST /api/v1/flocks/:flockId/log-todays-feeding`

One-call confirmation that today's feeding happened. The server reads every active schedule for the flock, creates one `feed_consumption` per schedule with `reason='feeding'` and `qty=schedule.qtyPerDay`, and runs FIFO drain across the available lots — **all in one transaction**.

| Method | Path | Body | Response data | Errors |
|---|---|---|---|---|
| POST | `/api/v1/flocks/:flockId/log-todays-feeding` | `LogTodaysFeedingBody` | `FeedConsumption[]` (with `lots` for each) | 400, 404, 409, **422** |

**`LogTodaysFeedingBody`**
```
{
  "date": "2026-04-14"   // optional — defaults to server's current date
}
```

The `date` field exists for back-filling missed days. In normal use the frontend can send an empty body `{}`.

**Response (200)** — array of `FeedConsumption` objects, each with their `lots` FIFO breakdown (same shape as `POST /feed-consumptions` from PR #19):
```
{
  "status": "success",
  "data": [
    {
      "id": "cons5678",
      "flockId": "flock123",
      "feedTypeId": "hayid001",
      "consumedAt": "2026-04-14",
      "qty": 1.0,
      "reason": "feeding",
      "totalCost": 1.5,
      "lots": [
        { "id": "link999", "lotId": "lot00abc", "qtyDrawn": 1.0, "unitPriceSnapshot": 1.5 }
      ],
      "...": "..."
    },
    {
      "id": "cons5679",
      "feedTypeId": "grainid01",
      "qty": 0.5,
      "reason": "feeding",
      "totalCost": 1.0,
      "lots": [...]
    }
  ]
}
```

**Error cases:**

| Code | Cause | Frontend handling |
|---|---|---|
| 400 | No active feeding schedules for this flock today, OR already logged for today (idempotency) | Show "Already logged" or "Set up a feeding schedule first" |
| 404 | Flock not on current farm | Auth/scope problem |
| 422 | Insufficient stock on at least one feed type — **whole batch rolled back, nothing was logged** | Show which feed type is empty (message includes requested vs available) and prompt user to record a purchase |

The frontend should treat this endpoint as **all-or-nothing**: either every schedule produced a row, or none did. There is no partial-success state.

---

### Recommended UX flow

1. User opens a flock detail page.
2. Frontend lists active feeding schedules via `GET /feeding-schedules?flockId=X&activeOnly=true`.
3. A "Log today's feeding" button calls `POST /flocks/:flockId/log-todays-feeding` with empty body.
4. On 200 → show the created consumptions and update any cached `qtyRemaining` for the affected lots.
5. On 422 → show the insufficient-stock error and link the user to "Record a feed purchase" (Phase 1's `POST /feed-lots`).
6. On 400 with `"already exists"` → show "Already logged for today" and disable the button.

---

## Test plan

- [x] All 13 new tests pass (7 schedule CRUD + 6 log-todays-feeding)
- [x] Full suite green (226/226, no regressions)
- [x] Active window filtering (today inside / past `activeTo` window)
- [x] Partial unique index blocks a second open-ended schedule per `(flock, feed_type)`
- [x] `log-todays-feeding` batch atomic — insufficient stock on one feed type rolls back the whole batch
- [x] Idempotency — second call same day returns 400, no double-drain
- [x] Closing one schedule (set `activeTo`) and creating a new open-ended one works
- [ ] Manual smoke via Bruno: create two feed types + lots → create two schedules for one flock → call log-todays-feeding → verify both consumptions returned with correct FIFO breakdown → call again → verify 400 → drain one lot manually → verify next-day call returns 422 with rollback