### PR TITLE
feat(report): add group_by=asset to /reports/aggregate

### DIFF
--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -16,7 +16,7 @@ One row per (asset, currency). Events with NULL amount/currency are excluded. Di
 
 _Generic time-bucketed aggregate over events of one type_
 
-Dispatches on `type` and returns uniform `{bucket, group, measure, value}` rows.
+Dispatches on `type` and returns uniform `{bucket, group, group_label, measure, value, asset_id}` rows.
 
 - production / observation: SUM(quantity) grouped by unit
 - mortality / acquisition: SUM(quantity) as headcount, no grouping
@@ -25,6 +25,16 @@ Dispatches on `type` and returns uniform `{bucket, group, measure, value}` rows.
 - reproductive: COUNT(*) of events
 
 Filters `unit`, `adjustment`, `currency` are ignored for types where they do not apply.
+
+**`group_by=asset`** breaks rows down per asset. Each row then carries a stable `group` key (the asset id as a string), a `group_label` (the asset name), and an `asset_id`. When `group_by` is omitted, rows are unchanged: `group_label` and `asset_id` stay `null`.
+
+Compatibility matrix — `type` vs `group_by`:
+
+| type | group_by=asset |
+| --- | --- |
+| mortality | supported |
+| acquisition | supported |
+| production / observation / inventory / expense / income / reproductive | rejected with 422 |
 
 **Responses:**
 - `200` → AggregateReport — Successful Response
@@ -82,6 +92,7 @@ _R4 — paginated event timeline for one individual_
 - `measure` ('sum_quantity' | 'sum_amount' | 'count', required)
 - `bucket` ('day' | 'week' | 'month', required)
 - `group_key` (string | null, required)
+- `group_by` ('asset' | null, optional)
 
 ### AggregateReport
 
@@ -92,8 +103,10 @@ _R4 — paginated event timeline for one individual_
 
 - `bucket` (string (date-time), required)
 - `group` (string | null, required)
+- `group_label` (string | null, optional)
 - `measure` ('sum_quantity' | 'sum_amount' | 'count', required)
 - `value` (string, required)
+- `asset_id` (integer | null, optional)
 
 ### CostPerUnitReport
 
@@ -205,6 +218,10 @@ _R4 — paginated event timeline for one individual_
 ### EventType
 
 **Values:** `production` | `expense` | `income` | `observation` | `reproductive` | `acquisition` | `mortality` | `inventory`
+
+### GroupBy
+
+**Values:** `asset`
 
 ### InventoryAdjustment
 

--- a/openapi.json
+++ b/openapi.json
@@ -15,6 +15,16 @@
           "bucket": {
             "$ref": "#/components/schemas/Bucket"
           },
+          "group_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GroupBy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "group_key": {
             "anyOf": [
               {
@@ -64,6 +74,17 @@
       },
       "AggregateRow": {
         "properties": {
+          "asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Asset Id"
+          },
           "bucket": {
             "format": "date-time",
             "title": "Bucket",
@@ -79,6 +100,17 @@
               }
             ],
             "title": "Group"
+          },
+          "group_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group Label"
           },
           "measure": {
             "$ref": "#/components/schemas/AggregateMeasure"
@@ -1603,6 +1635,13 @@
         },
         "title": "FarmUpdate",
         "type": "object"
+      },
+      "GroupBy": {
+        "enum": [
+          "asset"
+        ],
+        "title": "GroupBy",
+        "type": "string"
       },
       "HTTPValidationError": {
         "properties": {
@@ -4440,7 +4479,7 @@
     },
     "/api/v1/farms/{farm_id}/reports/aggregate": {
       "get": {
-        "description": "Dispatches on `type` and returns uniform `{bucket, group, measure, value}` rows.\n\n- production / observation: SUM(quantity) grouped by unit\n- mortality / acquisition: SUM(quantity) as headcount, no grouping\n- inventory: net flow within window (increments minus decrements).   Pass `adjustment=reset|increment|decrement` to isolate one kind.\n- expense / income: SUM(amount) grouped by currency\n- reproductive: COUNT(*) of events\n\nFilters `unit`, `adjustment`, `currency` are ignored for types where they do not apply.",
+        "description": "Dispatches on `type` and returns uniform `{bucket, group, group_label, measure, value, asset_id}` rows.\n\n- production / observation: SUM(quantity) grouped by unit\n- mortality / acquisition: SUM(quantity) as headcount, no grouping\n- inventory: net flow within window (increments minus decrements).   Pass `adjustment=reset|increment|decrement` to isolate one kind.\n- expense / income: SUM(amount) grouped by currency\n- reproductive: COUNT(*) of events\n\nFilters `unit`, `adjustment`, `currency` are ignored for types where they do not apply.\n\n**`group_by=asset`** breaks rows down per asset. Each row then carries a stable `group` key (the asset id as a string), a `group_label` (the asset name), and an `asset_id`. When `group_by` is omitted, rows are unchanged: `group_label` and `asset_id` stay `null`.\n\nCompatibility matrix \u2014 `type` vs `group_by`:\n\n| type | group_by=asset |\n| --- | --- |\n| mortality | supported |\n| acquisition | supported |\n| production / observation / inventory / expense / income / reproductive | rejected with 422 |",
         "operationId": "reports_aggregate_report",
         "parameters": [
           {
@@ -4501,6 +4540,22 @@
             "schema": {
               "$ref": "#/components/schemas/Bucket",
               "default": "day"
+            }
+          },
+          {
+            "in": "query",
+            "name": "group_by",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GroupBy"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group By"
             }
           },
           {

--- a/src/ovejitas/features/report/aggregate.py
+++ b/src/ovejitas/features/report/aggregate.py
@@ -1,177 +1,65 @@
-"""Per-type builders for the generic /reports/aggregate endpoint.
+"""Dispatch for the generic /reports/aggregate endpoint.
 
-Each builder turns events of one EventType into a stream of
-AggregateRow{bucket, group, measure, value}. The router stitches them
-into AggregateReport with a meta block describing how to render.
+Per-type builders live in builders.py. This module maps each EventType to a
+builder, applies the optional ``group_by=asset`` breakdown, and wraps the
+result in AggregateMeta describing how to render the rows.
 """
 
 from collections.abc import Callable, Coroutine
-from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import Select, case, func, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ovejitas.core.errors import ValidationError
-from ovejitas.core.filters import apply_date_range
+from ovejitas.features.asset.models import Asset
 from ovejitas.features.event.models import Event
-from ovejitas.features.event.types import EventType, InventoryAdjustment
+from ovejitas.features.event.types import EventType
+from ovejitas.features.report.builders import (
+    _amount_by_currency,
+    _bucket_col,
+    _count,
+    _headcount,
+    _inventory_signed,
+    _quantity_by_unit,
+    _scope,
+)
 from ovejitas.features.report.schemas import (
     AggregateMeasure,
     AggregateMeta,
     AggregateQuery,
     AggregateRow,
-    Bucket,
+    GroupBy,
 )
 
 
-def _scope(
-    stmt: Select[Any],
-    farm_id: int,
-    date_from: datetime | None,
-    date_to: datetime | None,
-    asset_id: int | None,
-) -> Select[Any]:
-    stmt = stmt.where(Event.farm_id == farm_id)
-    stmt = apply_date_range(stmt, Event.occurred_at, date_from, date_to)
-    if asset_id is not None:
-        stmt = stmt.where(Event.asset_id == asset_id)
-    return stmt
-
-
-def _bucket_col(bucket: Bucket) -> Any:
-    return func.date_trunc(bucket.value, Event.occurred_at).label("bucket")
-
-
-async def _quantity_by_unit(
+async def _headcount_by_asset(
     db: AsyncSession, farm_id: int, q: AggregateQuery
 ) -> list[AggregateRow]:
+    """SUM(quantity) headcount, one row per (bucket, asset)."""
     b = _bucket_col(q.bucket)
     stmt = (
-        select(b, Event.unit.label("unit"), func.sum(Event.quantity).label("value"))
-        .where(
-            Event.type == q.type,
-            Event.quantity.is_not(None),
-            Event.unit.is_not(None),
+        select(
+            b,
+            Event.asset_id.label("asset_id"),
+            Asset.name.label("asset_name"),
+            func.sum(Event.quantity).label("value"),
         )
-        .group_by(b, Event.unit)
-        .order_by(b, Event.unit)
-    )
-    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
-    if q.unit is not None:
-        stmt = stmt.where(Event.unit == q.unit)
-    rows = (await db.execute(stmt)).all()
-    return [
-        AggregateRow(
-            bucket=r.bucket,
-            group=r.unit.value,
-            measure=AggregateMeasure.SUM_QUANTITY,
-            value=Decimal(r.value),
-        )
-        for r in rows
-    ]
-
-
-async def _headcount(db: AsyncSession, farm_id: int, q: AggregateQuery) -> list[AggregateRow]:
-    b = _bucket_col(q.bucket)
-    stmt = (
-        select(b, func.sum(Event.quantity).label("value"))
+        .join(Asset, Asset.id == Event.asset_id)
         .where(Event.type == q.type, Event.quantity.is_not(None))
-        .group_by(b)
-        .order_by(b)
+        .group_by(b, Event.asset_id, Asset.name)
+        .order_by(b, Asset.name)
     )
     stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
     rows = (await db.execute(stmt)).all()
     return [
         AggregateRow(
             bucket=r.bucket,
-            group=None,
+            group=str(r.asset_id),
+            group_label=r.asset_name,
+            asset_id=r.asset_id,
             measure=AggregateMeasure.SUM_QUANTITY,
-            value=Decimal(r.value),
-        )
-        for r in rows
-    ]
-
-
-async def _inventory_signed(
-    db: AsyncSession, farm_id: int, q: AggregateQuery
-) -> list[AggregateRow]:
-    """Net flow within window. Resets excluded unless explicitly filtered for."""
-    b = _bucket_col(q.bucket)
-    if q.adjustment is None:
-        value = func.sum(
-            case(
-                (Event.adjustment == InventoryAdjustment.INCREMENT, Event.quantity),
-                (Event.adjustment == InventoryAdjustment.DECREMENT, -Event.quantity),
-                else_=Decimal(0),
-            )
-        ).label("value")
-        stmt = select(b, Event.unit.label("unit"), value).where(
-            Event.type == EventType.INVENTORY,
-            Event.adjustment.in_([InventoryAdjustment.INCREMENT, InventoryAdjustment.DECREMENT]),
-        )
-    else:
-        stmt = select(b, Event.unit.label("unit"), func.sum(Event.quantity).label("value")).where(
-            Event.type == EventType.INVENTORY, Event.adjustment == q.adjustment
-        )
-    stmt = stmt.group_by(b, Event.unit).order_by(b, Event.unit)
-    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
-    if q.unit is not None:
-        stmt = stmt.where(Event.unit == q.unit)
-    rows = (await db.execute(stmt)).all()
-    return [
-        AggregateRow(
-            bucket=r.bucket,
-            group=r.unit.value,
-            measure=AggregateMeasure.SUM_QUANTITY,
-            value=Decimal(r.value or 0),
-        )
-        for r in rows
-    ]
-
-
-async def _amount_by_currency(
-    db: AsyncSession, farm_id: int, q: AggregateQuery
-) -> list[AggregateRow]:
-    b = _bucket_col(q.bucket)
-    stmt = (
-        select(b, Event.currency.label("currency"), func.sum(Event.amount).label("value"))
-        .where(
-            Event.type == q.type,
-            Event.amount.is_not(None),
-            Event.currency.is_not(None),
-        )
-        .group_by(b, Event.currency)
-        .order_by(b, Event.currency)
-    )
-    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
-    if q.currency is not None:
-        stmt = stmt.where(Event.currency == q.currency)
-    rows = (await db.execute(stmt)).all()
-    return [
-        AggregateRow(
-            bucket=r.bucket,
-            group=r.currency,
-            measure=AggregateMeasure.SUM_AMOUNT,
-            value=Decimal(r.value),
-        )
-        for r in rows
-    ]
-
-
-async def _count(db: AsyncSession, farm_id: int, q: AggregateQuery) -> list[AggregateRow]:
-    b = _bucket_col(q.bucket)
-    stmt = (
-        select(b, func.count().label("value")).where(Event.type == q.type).group_by(b).order_by(b)
-    )
-    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
-    rows = (await db.execute(stmt)).all()
-    return [
-        AggregateRow(
-            bucket=r.bucket,
-            group=None,
-            measure=AggregateMeasure.COUNT,
             value=Decimal(r.value),
         )
         for r in rows
@@ -191,6 +79,9 @@ _DISPATCH: dict[EventType, tuple[Builder, AggregateMeasure, str | None]] = {
     EventType.REPRODUCTIVE: (_count, AggregateMeasure.COUNT, None),
 }
 
+# Event types whose rows can be broken down per asset via group_by=asset.
+_ASSET_GROUPABLE: frozenset[EventType] = frozenset({EventType.MORTALITY, EventType.ACQUISITION})
+
 
 async def aggregate(
     db: AsyncSession, farm_id: int, q: AggregateQuery
@@ -199,6 +90,17 @@ async def aggregate(
     if entry is None:
         raise ValidationError(f"Aggregate not supported for type={q.type.value}")
     builder, measure, group_key = entry
+    if q.group_by is GroupBy.ASSET:
+        if q.type not in _ASSET_GROUPABLE:
+            raise ValidationError(f"group_by=asset is not supported for type={q.type.value}")
+        builder = _headcount_by_asset
+        group_key = "asset"
     rows = await builder(db, farm_id, q)
-    meta = AggregateMeta(type=q.type, measure=measure, bucket=q.bucket, group_key=group_key)
+    meta = AggregateMeta(
+        type=q.type,
+        measure=measure,
+        bucket=q.bucket,
+        group_key=group_key,
+        group_by=q.group_by,
+    )
     return rows, meta

--- a/src/ovejitas/features/report/builders.py
+++ b/src/ovejitas/features/report/builders.py
@@ -1,0 +1,174 @@
+"""Per-type builders for the generic /reports/aggregate endpoint.
+
+Each builder turns events of one EventType into a stream of
+AggregateRow{bucket, group, measure, value}. Dispatch lives in aggregate.py.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import Select, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.filters import apply_date_range
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.types import EventType, InventoryAdjustment
+from ovejitas.features.report.schemas import (
+    AggregateMeasure,
+    AggregateQuery,
+    AggregateRow,
+    Bucket,
+)
+
+
+def _scope(
+    stmt: Select[Any],
+    farm_id: int,
+    date_from: datetime | None,
+    date_to: datetime | None,
+    asset_id: int | None,
+) -> Select[Any]:
+    stmt = stmt.where(Event.farm_id == farm_id)
+    stmt = apply_date_range(stmt, Event.occurred_at, date_from, date_to)
+    if asset_id is not None:
+        stmt = stmt.where(Event.asset_id == asset_id)
+    return stmt
+
+
+def _bucket_col(bucket: Bucket) -> Any:
+    return func.date_trunc(bucket.value, Event.occurred_at).label("bucket")
+
+
+async def _quantity_by_unit(
+    db: AsyncSession, farm_id: int, q: AggregateQuery
+) -> list[AggregateRow]:
+    b = _bucket_col(q.bucket)
+    stmt = (
+        select(b, Event.unit.label("unit"), func.sum(Event.quantity).label("value"))
+        .where(
+            Event.type == q.type,
+            Event.quantity.is_not(None),
+            Event.unit.is_not(None),
+        )
+        .group_by(b, Event.unit)
+        .order_by(b, Event.unit)
+    )
+    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
+    if q.unit is not None:
+        stmt = stmt.where(Event.unit == q.unit)
+    rows = (await db.execute(stmt)).all()
+    return [
+        AggregateRow(
+            bucket=r.bucket,
+            group=r.unit.value,
+            measure=AggregateMeasure.SUM_QUANTITY,
+            value=Decimal(r.value),
+        )
+        for r in rows
+    ]
+
+
+async def _headcount(db: AsyncSession, farm_id: int, q: AggregateQuery) -> list[AggregateRow]:
+    b = _bucket_col(q.bucket)
+    stmt = (
+        select(b, func.sum(Event.quantity).label("value"))
+        .where(Event.type == q.type, Event.quantity.is_not(None))
+        .group_by(b)
+        .order_by(b)
+    )
+    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
+    rows = (await db.execute(stmt)).all()
+    return [
+        AggregateRow(
+            bucket=r.bucket,
+            group=None,
+            measure=AggregateMeasure.SUM_QUANTITY,
+            value=Decimal(r.value),
+        )
+        for r in rows
+    ]
+
+
+async def _inventory_signed(
+    db: AsyncSession, farm_id: int, q: AggregateQuery
+) -> list[AggregateRow]:
+    """Net flow within window. Resets excluded unless explicitly filtered for."""
+    b = _bucket_col(q.bucket)
+    if q.adjustment is None:
+        value = func.sum(
+            case(
+                (Event.adjustment == InventoryAdjustment.INCREMENT, Event.quantity),
+                (Event.adjustment == InventoryAdjustment.DECREMENT, -Event.quantity),
+                else_=Decimal(0),
+            )
+        ).label("value")
+        stmt = select(b, Event.unit.label("unit"), value).where(
+            Event.type == EventType.INVENTORY,
+            Event.adjustment.in_([InventoryAdjustment.INCREMENT, InventoryAdjustment.DECREMENT]),
+        )
+    else:
+        stmt = select(b, Event.unit.label("unit"), func.sum(Event.quantity).label("value")).where(
+            Event.type == EventType.INVENTORY, Event.adjustment == q.adjustment
+        )
+    stmt = stmt.group_by(b, Event.unit).order_by(b, Event.unit)
+    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
+    if q.unit is not None:
+        stmt = stmt.where(Event.unit == q.unit)
+    rows = (await db.execute(stmt)).all()
+    return [
+        AggregateRow(
+            bucket=r.bucket,
+            group=r.unit.value,
+            measure=AggregateMeasure.SUM_QUANTITY,
+            value=Decimal(r.value or 0),
+        )
+        for r in rows
+    ]
+
+
+async def _amount_by_currency(
+    db: AsyncSession, farm_id: int, q: AggregateQuery
+) -> list[AggregateRow]:
+    b = _bucket_col(q.bucket)
+    stmt = (
+        select(b, Event.currency.label("currency"), func.sum(Event.amount).label("value"))
+        .where(
+            Event.type == q.type,
+            Event.amount.is_not(None),
+            Event.currency.is_not(None),
+        )
+        .group_by(b, Event.currency)
+        .order_by(b, Event.currency)
+    )
+    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
+    if q.currency is not None:
+        stmt = stmt.where(Event.currency == q.currency)
+    rows = (await db.execute(stmt)).all()
+    return [
+        AggregateRow(
+            bucket=r.bucket,
+            group=r.currency,
+            measure=AggregateMeasure.SUM_AMOUNT,
+            value=Decimal(r.value),
+        )
+        for r in rows
+    ]
+
+
+async def _count(db: AsyncSession, farm_id: int, q: AggregateQuery) -> list[AggregateRow]:
+    b = _bucket_col(q.bucket)
+    stmt = (
+        select(b, func.count().label("value")).where(Event.type == q.type).group_by(b).order_by(b)
+    )
+    stmt = _scope(stmt, farm_id, q.date_from, q.date_to, q.asset_id)
+    rows = (await db.execute(stmt)).all()
+    return [
+        AggregateRow(
+            bucket=r.bucket,
+            group=None,
+            measure=AggregateMeasure.COUNT,
+            value=Decimal(r.value),
+        )
+        for r in rows
+    ]

--- a/src/ovejitas/features/report/router.py
+++ b/src/ovejitas/features/report/router.py
@@ -72,14 +72,27 @@ async def profitability(
     response_model=AggregateReport,
     summary="Generic time-bucketed aggregate over events of one type",
     description=(
-        "Dispatches on `type` and returns uniform `{bucket, group, measure, value}` rows.\n\n"
+        "Dispatches on `type` and returns uniform "
+        "`{bucket, group, group_label, measure, value, asset_id}` rows.\n\n"
         "- production / observation: SUM(quantity) grouped by unit\n"
         "- mortality / acquisition: SUM(quantity) as headcount, no grouping\n"
         "- inventory: net flow within window (increments minus decrements). "
         "  Pass `adjustment=reset|increment|decrement` to isolate one kind.\n"
         "- expense / income: SUM(amount) grouped by currency\n"
         "- reproductive: COUNT(*) of events\n\n"
-        "Filters `unit`, `adjustment`, `currency` are ignored for types where they do not apply."
+        "Filters `unit`, `adjustment`, `currency` are ignored for types where "
+        "they do not apply.\n\n"
+        "**`group_by=asset`** breaks rows down per asset. Each row then carries a stable "
+        "`group` key (the asset id as a string), a `group_label` (the asset name), and an "
+        "`asset_id`. When `group_by` is omitted, rows are unchanged: `group_label` and "
+        "`asset_id` stay `null`.\n\n"
+        "Compatibility matrix — `type` vs `group_by`:\n\n"
+        "| type | group_by=asset |\n"
+        "| --- | --- |\n"
+        "| mortality | supported |\n"
+        "| acquisition | supported |\n"
+        "| production / observation / inventory / expense / income / reproductive | "
+        "rejected with 422 |\n"
     ),
 )
 async def aggregate_report(

--- a/src/ovejitas/features/report/schemas.py
+++ b/src/ovejitas/features/report/schemas.py
@@ -14,6 +14,10 @@ class Bucket(StrEnum):
     MONTH = "month"
 
 
+class GroupBy(StrEnum):
+    ASSET = "asset"
+
+
 class ProfitabilityRow(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -46,8 +50,10 @@ class AggregateMeasure(StrEnum):
 class AggregateRow(BaseModel):
     bucket: datetime
     group: str | None
+    group_label: str | None = None
     measure: AggregateMeasure
     value: Decimal
+    asset_id: int | None = None
 
 
 class AggregateMeta(BaseModel):
@@ -55,6 +61,7 @@ class AggregateMeta(BaseModel):
     measure: AggregateMeasure
     bucket: Bucket
     group_key: str | None
+    group_by: GroupBy | None = None
 
 
 class AggregateReport(BaseModel):
@@ -65,6 +72,7 @@ class AggregateReport(BaseModel):
 class AggregateQuery(FilterParams):
     type: EventType
     bucket: Bucket = Bucket.DAY
+    group_by: GroupBy | None = None
     asset_id: int | None = None
     unit: Unit | None = None
     adjustment: InventoryAdjustment | None = None

--- a/tests/integration/test_reports_aggregate.py
+++ b/tests/integration/test_reports_aggregate.py
@@ -81,6 +81,7 @@ class TestProductionAndObservation:
             "measure": "sum_quantity",
             "bucket": "day",
             "group_key": "unit",
+            "group_by": None,
         }
         by_day = {r["bucket"][:10]: Decimal(r["value"]) for r in body["data"]}
         assert by_day == {"2026-04-01": Decimal("15"), "2026-04-02": Decimal("7")}
@@ -382,3 +383,183 @@ class TestFilters:
         rows = resp.json()["data"]
         assert len(rows) == 1
         assert Decimal(rows[0]["value"]) == Decimal("5")
+
+
+async def _mortality(farm_id: int, asset_id: int, user_id: int, **kw: object) -> None:
+    await _event(
+        farm_id,
+        asset_id,
+        user_id,
+        type=EventType.MORTALITY,
+        unit=None,
+        **kw,
+    )
+
+
+class TestGroupByAsset:
+    async def test_group_by_asset_returns_one_row_per_asset(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        vacas = await _asset(authed_user.farm_id, name="Vacas")
+        ovejas = await _asset(authed_user.farm_id, name="Ovejas")
+        await _mortality(authed_user.farm_id, vacas, authed_user.user_id, quantity=Decimal("2"))
+        await _mortality(authed_user.farm_id, vacas, authed_user.user_id, quantity=Decimal("1"))
+        await _mortality(authed_user.farm_id, ovejas, authed_user.user_id, quantity=Decimal("4"))
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality", "bucket": "month", "group_by": "asset"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        by_asset = {r["group_label"]: r for r in body["data"]}
+        assert by_asset["Vacas"]["group"] == str(vacas)
+        assert by_asset["Vacas"]["asset_id"] == vacas
+        assert Decimal(by_asset["Vacas"]["value"]) == Decimal("3")
+        assert by_asset["Ovejas"]["asset_id"] == ovejas
+        assert Decimal(by_asset["Ovejas"]["value"]) == Decimal("4")
+
+    async def test_group_by_asset_sets_meta_group_by(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _asset(authed_user.farm_id, name="Vacas")
+        await _mortality(authed_user.farm_id, asset_id, authed_user.user_id, quantity=Decimal("1"))
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality", "group_by": "asset"},
+        )
+
+        meta = resp.json()["meta"]
+        assert meta["group_by"] == "asset"
+        assert meta["group_key"] == "asset"
+
+    async def test_acquisition_supports_group_by_asset(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _asset(authed_user.farm_id, name="Pollos")
+        await _event(
+            authed_user.farm_id,
+            asset_id,
+            authed_user.user_id,
+            type=EventType.ACQUISITION,
+            quantity=Decimal("5"),
+            unit=None,
+        )
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "acquisition", "group_by": "asset"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        row = resp.json()["data"][0]
+        assert row["asset_id"] == asset_id
+        assert row["group_label"] == "Pollos"
+
+    async def test_mortality_without_group_by_keeps_legacy_shape(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _asset(authed_user.farm_id, name="Vacas")
+        await _mortality(authed_user.farm_id, asset_id, authed_user.user_id, quantity=Decimal("2"))
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality"},
+        )
+
+        body = resp.json()
+        assert body["meta"]["group_by"] is None
+        row = body["data"][0]
+        assert row["group"] is None
+        assert row["group_label"] is None
+        assert row["asset_id"] is None
+
+    async def test_invalid_group_by_value_returns_422(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality", "group_by": "banana"},
+        )
+        assert resp.status_code == 422
+
+    async def test_group_by_asset_with_incompatible_type_returns_422(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "expense", "group_by": "asset"},
+        )
+        assert resp.status_code == 422
+
+    async def test_group_by_asset_empty_result(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality", "group_by": "asset"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == []
+        assert body["meta"]["group_by"] == "asset"
+
+    async def test_group_by_asset_respects_date_filter(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _asset(authed_user.farm_id, name="Vacas")
+        await _mortality(
+            authed_user.farm_id,
+            asset_id,
+            authed_user.user_id,
+            quantity=Decimal("2"),
+            when=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        await _mortality(
+            authed_user.farm_id,
+            asset_id,
+            authed_user.user_id,
+            quantity=Decimal("5"),
+            when=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={
+                "type": "mortality",
+                "group_by": "asset",
+                "date_from": "2026-03-20T00:00:00Z",
+            },
+        )
+
+        rows = resp.json()["data"]
+        assert len(rows) == 1
+        assert Decimal(rows[0]["value"]) == Decimal("5")
+
+    async def test_group_by_asset_respects_asset_id_filter(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        vacas = await _asset(authed_user.farm_id, name="Vacas")
+        ovejas = await _asset(authed_user.farm_id, name="Ovejas")
+        await _mortality(authed_user.farm_id, vacas, authed_user.user_id, quantity=Decimal("2"))
+        await _mortality(authed_user.farm_id, ovejas, authed_user.user_id, quantity=Decimal("4"))
+
+        resp = await client.get(
+            aggregate_url(authed_user.farm_id),
+            headers=authed_user.headers,
+            params={"type": "mortality", "group_by": "asset", "asset_id": vacas},
+        )
+
+        rows = resp.json()["data"]
+        assert len(rows) == 1
+        assert rows[0]["asset_id"] == vacas


### PR DESCRIPTION
## Summary
- Mortality/acquisition reports gave period totals with no per-asset breakdown — the frontend had to make N extra calls to see which asset had the losses.
- Adds an optional `group_by=asset` query param to `GET /api/v1/farms/{farm_id}/reports/aggregate` so a single request returns rows per (bucket, asset).
- Fully backward compatible: omitting `group_by` returns the exact legacy response shape.

## Changes
- **`schemas.py`** — new `GroupBy` enum; `group_by` on `AggregateQuery` and `AggregateMeta`; optional `group_label` / `asset_id` on `AggregateRow` (default `null`).
- **`aggregate.py`** — now the dispatcher; new `_headcount_by_asset` builder (`SUM(quantity)` JOIN `asset`, grouped by bucket + asset). Incompatible `type` + `group_by` rejected with `422`.
- **`builders.py`** (new) — the five existing per-type builders moved out of `aggregate.py`, which was already over the project's 200-line limit.
- **`router.py`** — endpoint description documents `group_by=asset` and a type-vs-`group_by` compatibility matrix.
- **`openapi.json` / `docs/api/reports.md`** — regenerated.
- **Tests** — 9 new `TestGroupByAsset` cases.

## Test plan
- [ ] `pytest tests/integration/test_reports_aggregate.py` — 21 pass (9 new + 12 existing)
- [ ] `mypy src` — clean
- [ ] `ruff check` / `ruff format --check` — clean
- [ ] `GET /reports/aggregate?type=mortality&bucket=month&group_by=asset` returns one row per (month, asset) with `group`, `group_label`, `asset_id` populated
- [ ] Same request without `group_by` returns the legacy shape (`group_label` / `asset_id` = `null`)
- [ ] `type=expense&group_by=asset` and `group_by=banana` both return `422`
