### PR TITLE
feat(individual): emit acquisition, mortality, and sale lifecycle events

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -71,18 +71,6 @@ _Delete an event_
 
 ## Types
 
-### EventAcquisitionCreate
-
-- `occurred_at` (string (date-time), required)
-- `individual_id` (integer | null, optional)
-- `category_id` (integer | null, optional)
-- `notes` (string | null, optional)
-- `payload` (object, optional)
-- `idempotency_key` (string | null, optional)
-- `type` (string, required)
-- `quantity` (number | string, required)
-- `amount` (number | string | null, optional)
-
 ### EventExpenseCreate
 
 - `occurred_at` (string (date-time), required)
@@ -117,17 +105,6 @@ _Delete an event_
 - `adjustment` ('increment' | 'decrement' | 'reset', required)
 - `quantity` (number | string, required)
 - `unit` ('g' | 'kg' | 'lb' | 't' | 'ml' | 'l' | 'gal' | 'unit' | 'dozen' | 'head', required)
-
-### EventMortalityCreate
-
-- `occurred_at` (string (date-time), required)
-- `individual_id` (integer | null, optional)
-- `category_id` (integer | null, optional)
-- `notes` (string | null, optional)
-- `payload` (object, optional)
-- `idempotency_key` (string | null, optional)
-- `type` (string, required)
-- `quantity` (number | string, required)
 
 ### EventObservationCreate
 

--- a/docs/api/individuals.md
+++ b/docs/api/individuals.md
@@ -14,7 +14,7 @@ _List individuals under an asset_
 
 _Create an individual under an asset_
 
-Asset must be in `individual` mode. Parents (if any) must belong to the same farm.
+Asset must be in `individual` mode. Parents (if any) must belong to the same farm. Atomically emits an ACQUISITION event; a `purchased` acquisition also books a paired EXPENSE event for `amount` in the farm's default currency.
 
 **Request body:**
 - `tag` (string, required)
@@ -23,6 +23,9 @@ Asset must be in `individual` mode. Parents (if any) must belong to the same far
 - `mother_id` (integer | null, optional)
 - `father_id` (integer | null, optional)
 - `extra` (object, optional)
+- `acquired_at` (string (date-time), optional)
+- `acquisition_method` ('purchased' | 'born' | 'other', optional)
+- `amount` (number | string | null, optional)
 
 **Responses:**
 - `201` → IndividualRead — Successful Response
@@ -40,6 +43,8 @@ _Get one individual_
 
 _Update an individual_
 
+Transitioning `status` to `deceased` emits a MORTALITY event; `died_at` (defaults to now) and `cause` are recorded on it. Transitioning `status` to `sold` emits an INCOME event; `sale_amount` is required, `sold_at` (defaults to now) and `buyer` are optional. Transitioning away from either state reverses its event. Death/sale fields are rejected unless the individual is (or is becoming) deceased/sold respectively.
+
 **Request body:**
 - `name` (string | null, optional)
 - `tag` (string | null, optional)
@@ -48,6 +53,14 @@ _Update an individual_
 - `father_id` (integer | null, optional)
 - `status` ('active' | 'sold' | 'deceased' | 'archived' | null, optional)
 - `extra` (object | null, optional)
+- `acquired_at` (string (date-time) | null, optional)
+- `acquisition_method` ('purchased' | 'born' | 'other' | null, optional)
+- `amount` (number | string | null, optional)
+- `died_at` (string (date-time) | null, optional)
+- `cause` (string | null, optional)
+- `sale_amount` (number | string | null, optional)
+- `sold_at` (string (date-time) | null, optional)
+- `buyer` (string | null, optional)
 
 **Responses:**
 - `200` → IndividualRead — Successful Response
@@ -75,6 +88,9 @@ _Delete an individual_
 - `mother_id` (integer | null, optional)
 - `father_id` (integer | null, optional)
 - `extra` (object, optional)
+- `acquired_at` (string (date-time), optional)
+- `acquisition_method` ('purchased' | 'born' | 'other', optional)
+- `amount` (number | string | null, optional)
 
 ### IndividualRead
 
@@ -88,6 +104,10 @@ _Delete an individual_
 - `father_id` (integer | null, required)
 - `status` ('active' | 'sold' | 'deceased' | 'archived', required)
 - `extra` (object, required)
+- `acquisition_event_id` (integer | null, required)
+- `acquisition_expense_event_id` (integer | null, required)
+- `mortality_event_id` (integer | null, required)
+- `sale_event_id` (integer | null, required)
 - `created_at` (string (date-time), required)
 - `updated_at` (string (date-time), required)
 
@@ -100,6 +120,14 @@ _Delete an individual_
 - `father_id` (integer | null, optional)
 - `status` ('active' | 'sold' | 'deceased' | 'archived' | null, optional)
 - `extra` (object | null, optional)
+- `acquired_at` (string (date-time) | null, optional)
+- `acquisition_method` ('purchased' | 'born' | 'other' | null, optional)
+- `amount` (number | string | null, optional)
+- `died_at` (string (date-time) | null, optional)
+- `cause` (string | null, optional)
+- `sale_amount` (number | string | null, optional)
+- `sold_at` (string (date-time) | null, optional)
+- `buyer` (string | null, optional)
 
 ### PageMeta
 
@@ -120,6 +148,10 @@ _Delete an individual_
 - `type` (string, required)
 - `input` (any, optional)
 - `ctx` (object, optional)
+
+### AcquisitionMethod
+
+**Values:** `purchased` | `born` | `other`
 
 ### IndividualStatus
 

--- a/migrations/versions/20260517_1100_add_individual_acquisition_event_fks.py
+++ b/migrations/versions/20260517_1100_add_individual_acquisition_event_fks.py
@@ -1,0 +1,68 @@
+"""add_individual_acquisition_event_fks
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-05-17 11:00:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "individual", sa.Column("acquisition_event_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "individual", sa.Column("acquisition_expense_event_id", sa.Integer(), nullable=True)
+    )
+    op.create_unique_constraint(
+        op.f("uq_individual_acquisition_event_id"), "individual", ["acquisition_event_id"]
+    )
+    op.create_unique_constraint(
+        op.f("uq_individual_acquisition_expense_event_id"),
+        "individual",
+        ["acquisition_expense_event_id"],
+    )
+    op.create_foreign_key(
+        op.f("fk_individual_acquisition_event_id_event"),
+        "individual",
+        "event",
+        ["acquisition_event_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        op.f("fk_individual_acquisition_expense_event_id_event"),
+        "individual",
+        "event",
+        ["acquisition_expense_event_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_individual_acquisition_expense_event_id_event"),
+        "individual",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_individual_acquisition_event_id_event"), "individual", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("uq_individual_acquisition_expense_event_id"), "individual", type_="unique"
+    )
+    op.drop_constraint(
+        op.f("uq_individual_acquisition_event_id"), "individual", type_="unique"
+    )
+    op.drop_column("individual", "acquisition_expense_event_id")
+    op.drop_column("individual", "acquisition_event_id")

--- a/migrations/versions/20260517_1200_add_individual_mortality_event_fk.py
+++ b/migrations/versions/20260517_1200_add_individual_mortality_event_fk.py
@@ -1,0 +1,43 @@
+"""add_individual_mortality_event_fk
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-05-17 12:00:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: str | None = "e5f6a7b8c9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "individual", sa.Column("mortality_event_id", sa.Integer(), nullable=True)
+    )
+    op.create_unique_constraint(
+        op.f("uq_individual_mortality_event_id"), "individual", ["mortality_event_id"]
+    )
+    op.create_foreign_key(
+        op.f("fk_individual_mortality_event_id_event"),
+        "individual",
+        "event",
+        ["mortality_event_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_individual_mortality_event_id_event"), "individual", type_="foreignkey"
+    )
+    op.drop_constraint(
+        op.f("uq_individual_mortality_event_id"), "individual", type_="unique"
+    )
+    op.drop_column("individual", "mortality_event_id")

--- a/migrations/versions/20260517_1300_add_individual_sale_event_fk.py
+++ b/migrations/versions/20260517_1300_add_individual_sale_event_fk.py
@@ -1,0 +1,39 @@
+"""add_individual_sale_event_fk
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-05-17 13:00:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: str | None = "f6a7b8c9d0e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("individual", sa.Column("sale_event_id", sa.Integer(), nullable=True))
+    op.create_unique_constraint(
+        op.f("uq_individual_sale_event_id"), "individual", ["sale_event_id"]
+    )
+    op.create_foreign_key(
+        op.f("fk_individual_sale_event_id_event"),
+        "individual",
+        "event",
+        ["sale_event_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_individual_sale_event_id_event"), "individual", type_="foreignkey"
+    )
+    op.drop_constraint(op.f("uq_individual_sale_event_id"), "individual", type_="unique")
+    op.drop_column("individual", "sale_event_id")

--- a/openapi.json
+++ b/openapi.json
@@ -1,6 +1,16 @@
 {
   "components": {
     "schemas": {
+      "AcquisitionMethod": {
+        "description": "How an individual entered the herd. Stored on the acquisition event's\npayload; ``purchased`` is the only method that books a paired expense.",
+        "enum": [
+          "purchased",
+          "born",
+          "other"
+        ],
+        "title": "AcquisitionMethod",
+        "type": "string"
+      },
       "AggregateMeasure": {
         "enum": [
           "sum_quantity",
@@ -1687,6 +1697,31 @@
       "IndividualCreate": {
         "additionalProperties": false,
         "properties": {
+          "acquired_at": {
+            "format": "date-time",
+            "title": "Acquired At",
+            "type": "string"
+          },
+          "acquisition_method": {
+            "$ref": "#/components/schemas/AcquisitionMethod",
+            "default": "other"
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
           "birth_date": {
             "anyOf": [
               {
@@ -1753,6 +1788,28 @@
       },
       "IndividualRead": {
         "properties": {
+          "acquisition_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Event Id"
+          },
+          "acquisition_expense_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Expense Event Id"
+          },
           "asset_id": {
             "title": "Asset Id",
             "type": "integer"
@@ -1798,6 +1855,17 @@
             "title": "Id",
             "type": "integer"
           },
+          "mortality_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mortality Event Id"
+          },
           "mother_id": {
             "anyOf": [
               {
@@ -1819,6 +1887,17 @@
               }
             ],
             "title": "Name"
+          },
+          "sale_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sale Event Id"
           },
           "status": {
             "$ref": "#/components/schemas/IndividualStatus"
@@ -1844,6 +1923,10 @@
           "father_id",
           "status",
           "extra",
+          "acquisition_event_id",
+          "acquisition_expense_event_id",
+          "mortality_event_id",
+          "sale_event_id",
           "created_at",
           "updated_at"
         ],
@@ -1863,6 +1946,44 @@
       "IndividualUpdate": {
         "additionalProperties": false,
         "properties": {
+          "acquired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquired At"
+          },
+          "acquisition_method": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionMethod"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
           "birth_date": {
             "anyOf": [
               {
@@ -1874,6 +1995,42 @@
               }
             ],
             "title": "Birth Date"
+          },
+          "buyer": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buyer"
+          },
+          "cause": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cause"
+          },
+          "died_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Died At"
           },
           "extra": {
             "anyOf": [
@@ -1920,6 +2077,34 @@
               }
             ],
             "title": "Name"
+          },
+          "sale_amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sale Amount"
+          },
+          "sold_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sold At"
           },
           "status": {
             "anyOf": [
@@ -4583,7 +4768,7 @@
         ]
       },
       "post": {
-        "description": "Asset must be in `individual` mode. Parents (if any) must belong to the same farm.",
+        "description": "Asset must be in `individual` mode. Parents (if any) must belong to the same farm. Atomically emits an ACQUISITION event; a `purchased` acquisition also books a paired EXPENSE event for `amount` in the farm's default currency.",
         "operationId": "individuals_create_individual",
         "parameters": [
           {
@@ -4769,6 +4954,7 @@
         ]
       },
       "patch": {
+        "description": "Transitioning `status` to `deceased` emits a MORTALITY event; `died_at` (defaults to now) and `cause` are recorded on it. Transitioning `status` to `sold` emits an INCOME event; `sale_amount` is required, `sold_at` (defaults to now) and `buyer` are optional. Transitioning away from either state reverses its event. Death/sale fields are rejected unless the individual is (or is becoming) deceased/sold respectively.",
         "operationId": "individuals_update_individual",
         "parameters": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -475,107 +475,6 @@
         "title": "CostPerUnitTotal",
         "type": "object"
       },
-      "EventAcquisitionCreate": {
-        "additionalProperties": false,
-        "properties": {
-          "amount": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Amount"
-          },
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key"
-          },
-          "individual_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Individual Id"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "occurred_at": {
-            "format": "date-time",
-            "title": "Occurred At",
-            "type": "string"
-          },
-          "payload": {
-            "additionalProperties": true,
-            "title": "Payload",
-            "type": "object"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              }
-            ],
-            "title": "Quantity"
-          },
-          "type": {
-            "const": "acquisition",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "occurred_at",
-          "type",
-          "quantity"
-        ],
-        "title": "EventAcquisitionCreate",
-        "type": "object"
-      },
       "EventCategoryCreate": {
         "additionalProperties": false,
         "properties": {
@@ -977,91 +876,6 @@
           "unit"
         ],
         "title": "EventInventoryCreate",
-        "type": "object"
-      },
-      "EventMortalityCreate": {
-        "additionalProperties": false,
-        "properties": {
-          "category_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Id"
-          },
-          "idempotency_key": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Idempotency Key"
-          },
-          "individual_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Individual Id"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "occurred_at": {
-            "format": "date-time",
-            "title": "Occurred At",
-            "type": "string"
-          },
-          "payload": {
-            "additionalProperties": true,
-            "title": "Payload",
-            "type": "object"
-          },
-          "quantity": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "number"
-              },
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              }
-            ],
-            "title": "Quantity"
-          },
-          "type": {
-            "const": "mortality",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "occurred_at",
-          "type",
-          "quantity"
-        ],
-        "title": "EventMortalityCreate",
         "type": "object"
       },
       "EventObservationCreate": {
@@ -4275,11 +4089,9 @@
               "schema": {
                 "discriminator": {
                   "mapping": {
-                    "acquisition": "#/components/schemas/EventAcquisitionCreate",
                     "expense": "#/components/schemas/EventExpenseCreate",
                     "income": "#/components/schemas/EventIncomeCreate",
                     "inventory": "#/components/schemas/EventInventoryCreate",
-                    "mortality": "#/components/schemas/EventMortalityCreate",
                     "observation": "#/components/schemas/EventObservationCreate",
                     "production": "#/components/schemas/EventProductionCreate",
                     "reproductive": "#/components/schemas/EventReproductiveCreate"
@@ -4301,12 +4113,6 @@
                   },
                   {
                     "$ref": "#/components/schemas/EventReproductiveCreate"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventAcquisitionCreate"
-                  },
-                  {
-                    "$ref": "#/components/schemas/EventMortalityCreate"
                   },
                   {
                     "$ref": "#/components/schemas/EventInventoryCreate"

--- a/src/ovejitas/features/event/reversal.py
+++ b/src/ovejitas/features/event/reversal.py
@@ -1,0 +1,18 @@
+"""Generic event-reversal plumbing shared by feature `reverse_*` helpers."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.features.event.models import Event
+
+
+async def delete_event_if_exists(db: AsyncSession, event_id: int | None) -> None:
+    """Delete an event by id when it exists; a no-op for a None or missing id.
+
+    The caller must clear any FK referencing the event and flush *before*
+    calling this, or the event's RESTRICT foreign keys block the delete.
+    """
+    if event_id is None:
+        return
+    event = await db.get(Event, event_id)
+    if event is not None:
+        await db.delete(event)

--- a/src/ovejitas/features/event/schemas.py
+++ b/src/ovejitas/features/event/schemas.py
@@ -43,15 +43,9 @@ class EventReproductiveCreate(_EventCreateBase):
     individual_id: int
 
 
-class EventAcquisitionCreate(_EventCreateBase):
-    type: Literal[EventType.ACQUISITION]
-    quantity: Decimal = Field(gt=0)
-    amount: Decimal | None = Field(default=None, gt=0)
-
-
-class EventMortalityCreate(_EventCreateBase):
-    type: Literal[EventType.MORTALITY]
-    quantity: Decimal = Field(gt=0)
+# NOTE: ACQUISITION and MORTALITY events are deliberately absent from EventCreate.
+# They are owned by individual lifecycle actions (IndividualService.create /
+# .update) and must never be hand-written via POST /events — see Philosophy 1.
 
 
 class EventInventoryCreate(_EventCreateBase):
@@ -73,8 +67,6 @@ EventCreate = Annotated[
     | EventIncomeCreate
     | EventObservationCreate
     | EventReproductiveCreate
-    | EventAcquisitionCreate
-    | EventMortalityCreate
     | EventInventoryCreate,
     Field(discriminator="type"),
 ]

--- a/src/ovejitas/features/event/types.py
+++ b/src/ovejitas/features/event/types.py
@@ -18,6 +18,15 @@ class InventoryAdjustment(StrEnum):
     RESET = "reset"
 
 
+class AcquisitionMethod(StrEnum):
+    """How an individual entered the herd. Stored on the acquisition event's
+    payload; ``purchased`` is the only method that books a paired expense."""
+
+    PURCHASED = "purchased"
+    BORN = "born"
+    OTHER = "other"
+
+
 class Unit(StrEnum):
     G = "g"
     KG = "kg"

--- a/src/ovejitas/features/individual/acquisition.py
+++ b/src/ovejitas/features/individual/acquisition.py
@@ -1,0 +1,179 @@
+"""Lifecycle of the events an individual's acquisition owns — the ACQUISITION
+event recording its entry into the herd and, when it was purchased, the paired
+EXPENSE event booking its cost.
+
+The individual service calls these helpers; it never builds acquisition events
+by hand. They emit / reconcile / reverse inside the caller's transaction — the
+caller owns commit/rollback.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError, ValidationError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.expense import reconcile_expense, reverse_expense
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.reversal import delete_event_if_exists
+from ovejitas.features.event.types import AcquisitionMethod, EventType
+from ovejitas.features.individual.models import Individual
+
+_ACQUISITION_SOURCE = "acquisition"
+
+
+def _acquisition_expense_event(
+    *,
+    individual: Individual,
+    asset: Asset,
+    amount: Decimal,
+    currency: str,
+    occurred_at: datetime,
+    user_id: int,
+) -> Event:
+    return Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        individual_id=individual.id,
+        type=EventType.EXPENSE,
+        occurred_at=occurred_at,
+        amount=amount,
+        currency=currency,
+        payload={"source": _ACQUISITION_SOURCE},
+        created_by=user_id,
+    )
+
+
+async def emit_acquisition(
+    db: AsyncSession,
+    *,
+    individual: Individual,
+    asset: Asset,
+    method: AcquisitionMethod,
+    occurred_at: datetime,
+    amount: Decimal | None,
+    currency: str | None,
+    user_id: int,
+) -> tuple[Event, Event | None]:
+    """Emit the ACQUISITION event and, when purchased, the paired EXPENSE event.
+
+    ``individual`` must already be flushed so its id is available.
+    """
+    acquisition = Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        individual_id=individual.id,
+        type=EventType.ACQUISITION,
+        occurred_at=occurred_at,
+        quantity=Decimal(1),
+        payload={"source": _ACQUISITION_SOURCE, "method": method.value},
+        created_by=user_id,
+    )
+    db.add(acquisition)
+    expense: Event | None = None
+    if method is AcquisitionMethod.PURCHASED:
+        assert amount is not None and currency is not None
+        expense = _acquisition_expense_event(
+            individual=individual,
+            asset=asset,
+            amount=amount,
+            currency=currency,
+            occurred_at=occurred_at,
+            user_id=user_id,
+        )
+        db.add(expense)
+    await db.flush()
+    return acquisition, expense
+
+
+async def reconcile_acquisition(
+    db: AsyncSession,
+    *,
+    individual: Individual,
+    asset: Asset,
+    updates: dict[str, Any],
+    currency: str,
+    user_id: int,
+) -> None:
+    """Sync the acquisition event (and paired expense) to the updated fields.
+
+    ``updates`` holds only the acquisition keys actually sent in the PATCH.
+    """
+    acquisition = await db.get(Event, individual.acquisition_event_id)
+    if acquisition is None:
+        raise NotFoundError("Paired acquisition event missing")
+    occurred_at = updates.get("acquired_at", acquisition.occurred_at)
+    method = updates.get("acquisition_method") or AcquisitionMethod(acquisition.payload["method"])
+    acquisition.occurred_at = occurred_at
+    acquisition.payload = {**acquisition.payload, "method": method.value}
+    await _reconcile_expense_side(
+        db,
+        individual=individual,
+        asset=asset,
+        updates=updates,
+        method=method,
+        occurred_at=occurred_at,
+        currency=currency,
+        user_id=user_id,
+    )
+    await db.flush()
+
+
+async def _reconcile_expense_side(
+    db: AsyncSession,
+    *,
+    individual: Individual,
+    asset: Asset,
+    updates: dict[str, Any],
+    method: AcquisitionMethod,
+    occurred_at: datetime,
+    currency: str,
+    user_id: int,
+) -> None:
+    expense = (
+        await db.get(Event, individual.acquisition_expense_event_id)
+        if individual.acquisition_expense_event_id is not None
+        else None
+    )
+    if method is not AcquisitionMethod.PURCHASED:
+        if updates.get("amount") is not None:
+            raise ValidationError("amount is only valid for a purchased acquisition")
+        if expense is not None:
+            individual.acquisition_expense_event_id = None
+            await db.flush()
+            await reverse_expense(db, event=expense)
+        return
+    amount = updates.get("amount", expense.amount if expense is not None else None)
+    if amount is None:
+        raise ValidationError("amount is required for a purchased acquisition")
+    if expense is None:
+        expense = _acquisition_expense_event(
+            individual=individual,
+            asset=asset,
+            amount=amount,
+            currency=currency,
+            occurred_at=occurred_at,
+            user_id=user_id,
+        )
+        db.add(expense)
+        await db.flush()
+        individual.acquisition_expense_event_id = expense.id
+    else:
+        await reconcile_expense(db, event=expense, amount=amount, occurred_at=occurred_at)
+
+
+async def reverse_acquisition(db: AsyncSession, *, individual: Individual) -> None:
+    """Detach and delete the acquisition event and any paired expense event.
+
+    The individual's FK columns are cleared and flushed first so deleting the
+    events does not trip their RESTRICT foreign keys.
+    """
+    event_ids = (individual.acquisition_expense_event_id, individual.acquisition_event_id)
+    individual.acquisition_event_id = None
+    individual.acquisition_expense_event_id = None
+    await db.flush()
+    for event_id in event_ids:
+        await delete_event_if_exists(db, event_id)
+    await db.flush()

--- a/src/ovejitas/features/individual/models.py
+++ b/src/ovejitas/features/individual/models.py
@@ -52,6 +52,33 @@ class Individual(Base, TimestampMixin):
         nullable=False,
         default=IndividualStatus.ACTIVE,
     )
+    # Paired events emitted by the acquisition flow. Nullable at the schema
+    # level — the service is the single writer and always sets the acquisition
+    # event; the expense event exists only for purchased acquisitions.
+    acquisition_event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event.id", ondelete="RESTRICT"),
+        nullable=True,
+        unique=True,
+    )
+    acquisition_expense_event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event.id", ondelete="RESTRICT"),
+        nullable=True,
+        unique=True,
+    )
+    # Set by the mortality flow when status transitions to ``deceased``;
+    # cleared when that transition is reversed.
+    mortality_event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event.id", ondelete="RESTRICT"),
+        nullable=True,
+        unique=True,
+    )
+    # Set by the sale flow when status transitions to ``sold``;
+    # cleared when that transition is reversed.
+    sale_event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event.id", ondelete="RESTRICT"),
+        nullable=True,
+        unique=True,
+    )
     extra: Mapped[dict[str, Any]] = mapped_column(
         JSONB,
         nullable=False,

--- a/src/ovejitas/features/individual/mortality.py
+++ b/src/ovejitas/features/individual/mortality.py
@@ -1,0 +1,116 @@
+"""Lifecycle of the MORTALITY event an individual owns — the closing entry in
+its ledger, emitted when its status transitions to ``deceased``.
+
+The individual service calls these helpers; it never builds mortality events by
+hand. They emit / reconcile / reverse inside the caller's transaction — the
+caller owns commit/rollback.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError, ValidationError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.reversal import delete_event_if_exists
+from ovejitas.features.event.types import EventType
+from ovejitas.features.individual.models import Individual, IndividualStatus
+
+_MORTALITY_SOURCE = "mortality"
+
+
+async def emit_mortality(
+    db: AsyncSession,
+    *,
+    individual: Individual,
+    asset: Asset,
+    occurred_at: datetime,
+    cause: str | None,
+    user_id: int,
+) -> Event:
+    """Emit the MORTALITY event. ``individual`` must already be flushed."""
+    mortality = Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        individual_id=individual.id,
+        type=EventType.MORTALITY,
+        occurred_at=occurred_at,
+        quantity=Decimal(1),
+        notes=cause,
+        payload={"source": _MORTALITY_SOURCE},
+        created_by=user_id,
+    )
+    db.add(mortality)
+    await db.flush()
+    return mortality
+
+
+async def reconcile_mortality(
+    db: AsyncSession, *, individual: Individual, updates: dict[str, Any]
+) -> None:
+    """Sync the mortality event to edited death details.
+
+    ``updates`` holds only the mortality keys actually sent in the PATCH.
+    """
+    mortality = await db.get(Event, individual.mortality_event_id)
+    if mortality is None:
+        raise NotFoundError("Paired mortality event missing")
+    if "died_at" in updates:
+        mortality.occurred_at = updates["died_at"]
+    if "cause" in updates:
+        mortality.notes = updates["cause"]
+    await db.flush()
+
+
+async def reverse_mortality(db: AsyncSession, *, individual: Individual) -> None:
+    """Detach and delete the mortality event.
+
+    The individual's FK column is cleared and flushed first so deleting the
+    event does not trip its RESTRICT foreign key.
+    """
+    event_id = individual.mortality_event_id
+    individual.mortality_event_id = None
+    await db.flush()
+    await delete_event_if_exists(db, event_id)
+    await db.flush()
+
+
+async def apply_mortality(
+    db: AsyncSession,
+    *,
+    asset: Asset,
+    individual: Individual,
+    new_status: IndividualStatus | None,
+    updates: dict[str, Any],
+    user_id: int,
+) -> None:
+    """Emit, reconcile, or reverse the mortality event for a status change.
+
+    Must run before ``individual.status`` is reassigned — it reads the current
+    status to detect the transition.
+    """
+    was_deceased = individual.status is IndividualStatus.DECEASED
+    will_be_deceased = (
+        new_status is IndividualStatus.DECEASED if new_status is not None else was_deceased
+    )
+    if not will_be_deceased:
+        if updates:
+            raise ValidationError("died_at/cause are only valid for a deceased individual")
+        if was_deceased:
+            await reverse_mortality(db, individual=individual)
+        return
+    if not was_deceased:
+        event = await emit_mortality(
+            db,
+            individual=individual,
+            asset=asset,
+            occurred_at=updates.get("died_at") or datetime.now(UTC),
+            cause=updates.get("cause"),
+            user_id=user_id,
+        )
+        individual.mortality_event_id = event.id
+    elif updates:
+        await reconcile_mortality(db, individual=individual, updates=updates)

--- a/src/ovejitas/features/individual/router.py
+++ b/src/ovejitas/features/individual/router.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Query, status
 from ovejitas.core.deps import DBSession
 from ovejitas.core.pagination import Page, PageParams
 from ovejitas.features.asset.deps import AssetDep
+from ovejitas.features.farm_member.deps import FarmMembership
 from ovejitas.features.individual.schemas import (
     IndividualCreate,
     IndividualFilters,
@@ -51,15 +52,18 @@ async def list_individuals(
     status_code=status.HTTP_201_CREATED,
     summary="Create an individual under an asset",
     description=(
-        "Asset must be in `individual` mode. Parents (if any) must belong to the same farm."
+        "Asset must be in `individual` mode. Parents (if any) must belong to the same farm. "
+        "Atomically emits an ACQUISITION event; a `purchased` acquisition also books a "
+        "paired EXPENSE event for `amount` in the farm's default currency."
     ),
 )
 async def create_individual(
     asset: AssetDep,
     data: IndividualCreate,
     svc: IndividualSvc,
+    membership: FarmMembership,
 ) -> IndividualRead:
-    return IndividualRead.model_validate(await svc.create(asset, data))
+    return IndividualRead.model_validate(await svc.create(asset, membership.user_id, data))
 
 
 @router.get(
@@ -79,14 +83,25 @@ async def get_individual(
     "/{individual_id}",
     response_model=IndividualRead,
     summary="Update an individual",
+    description=(
+        "Transitioning `status` to `deceased` emits a MORTALITY event; `died_at` "
+        "(defaults to now) and `cause` are recorded on it. Transitioning `status` "
+        "to `sold` emits an INCOME event; `sale_amount` is required, `sold_at` "
+        "(defaults to now) and `buyer` are optional. Transitioning away from either "
+        "state reverses its event. Death/sale fields are rejected unless the "
+        "individual is (or is becoming) deceased/sold respectively."
+    ),
 )
 async def update_individual(
     asset: AssetDep,
     individual_id: int,
     data: IndividualUpdate,
     svc: IndividualSvc,
+    membership: FarmMembership,
 ) -> IndividualRead:
-    return IndividualRead.model_validate(await svc.update(asset, individual_id, data))
+    return IndividualRead.model_validate(
+        await svc.update(asset, individual_id, membership.user_id, data)
+    )
 
 
 @router.delete(

--- a/src/ovejitas/features/individual/sale.py
+++ b/src/ovejitas/features/individual/sale.py
@@ -1,0 +1,131 @@
+"""Lifecycle of the INCOME event an individual's sale owns — the revenue entry
+in its ledger, emitted when its status transitions to ``sold``.
+
+The individual service calls these helpers; it never builds sale events by
+hand. They emit / reconcile / reverse inside the caller's transaction — the
+caller owns commit/rollback.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError, ValidationError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.reversal import delete_event_if_exists
+from ovejitas.features.event.types import EventType
+from ovejitas.features.individual.models import Individual, IndividualStatus
+
+_SALE_SOURCE = "sale"
+
+
+def _sale_payload(buyer: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"source": _SALE_SOURCE}
+    if buyer is not None:
+        payload["buyer"] = buyer
+    return payload
+
+
+async def emit_sale(
+    db: AsyncSession,
+    *,
+    individual: Individual,
+    asset: Asset,
+    occurred_at: datetime,
+    amount: Decimal,
+    currency: str,
+    buyer: str | None,
+    user_id: int,
+) -> Event:
+    """Emit the INCOME event for a sale. ``individual`` must already be flushed."""
+    sale = Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        individual_id=individual.id,
+        type=EventType.INCOME,
+        occurred_at=occurred_at,
+        amount=amount,
+        currency=currency,
+        payload=_sale_payload(buyer),
+        created_by=user_id,
+    )
+    db.add(sale)
+    await db.flush()
+    return sale
+
+
+async def reconcile_sale(
+    db: AsyncSession, *, individual: Individual, updates: dict[str, Any]
+) -> None:
+    """Sync the sale income event to edited sale details.
+
+    ``updates`` holds only the sale keys actually sent in the PATCH.
+    """
+    sale = await db.get(Event, individual.sale_event_id)
+    if sale is None:
+        raise NotFoundError("Paired sale event missing")
+    if "sold_at" in updates:
+        sale.occurred_at = updates["sold_at"]
+    if "sale_amount" in updates:
+        sale.amount = updates["sale_amount"]
+    if "buyer" in updates:
+        sale.payload = _sale_payload(updates["buyer"])
+    await db.flush()
+
+
+async def reverse_sale(db: AsyncSession, *, individual: Individual) -> None:
+    """Detach and delete the sale income event.
+
+    The individual's FK column is cleared and flushed first so deleting the
+    event does not trip its RESTRICT foreign key.
+    """
+    event_id = individual.sale_event_id
+    individual.sale_event_id = None
+    await db.flush()
+    await delete_event_if_exists(db, event_id)
+    await db.flush()
+
+
+async def apply_sale(
+    db: AsyncSession,
+    *,
+    asset: Asset,
+    individual: Individual,
+    new_status: IndividualStatus | None,
+    updates: dict[str, Any],
+    currency: str,
+    user_id: int,
+) -> None:
+    """Emit, reconcile, or reverse the sale income event for a status change.
+
+    Must run before ``individual.status`` is reassigned — it reads the current
+    status to detect the transition.
+    """
+    was_sold = individual.status is IndividualStatus.SOLD
+    will_be_sold = new_status is IndividualStatus.SOLD if new_status is not None else was_sold
+    if not will_be_sold:
+        if updates:
+            raise ValidationError("sale_amount/sold_at/buyer are only valid for a sold individual")
+        if was_sold:
+            await reverse_sale(db, individual=individual)
+        return
+    if not was_sold:
+        amount = updates.get("sale_amount")
+        if amount is None:
+            raise ValidationError("sale_amount is required when selling an individual")
+        event = await emit_sale(
+            db,
+            individual=individual,
+            asset=asset,
+            occurred_at=updates.get("sold_at") or datetime.now(UTC),
+            amount=amount,
+            currency=currency,
+            buyer=updates.get("buyer"),
+            user_id=user_id,
+        )
+        individual.sale_event_id = event.id
+    elif updates:
+        await reconcile_sale(db, individual=individual, updates=updates)

--- a/src/ovejitas/features/individual/schemas.py
+++ b/src/ovejitas/features/individual/schemas.py
@@ -1,11 +1,17 @@
-from datetime import date, datetime
-from typing import Any
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ovejitas.core.filters import FilterParams
 from ovejitas.core.schemas import OptionalStr, StrictModel
+from ovejitas.features.event.types import AcquisitionMethod
 from ovejitas.features.individual.models import IndividualStatus
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
 
 
 class IndividualCreate(StrictModel):
@@ -15,6 +21,18 @@ class IndividualCreate(StrictModel):
     mother_id: int | None = None
     father_id: int | None = None
     extra: dict[str, Any] = Field(default_factory=dict)
+    acquired_at: datetime = Field(default_factory=_utc_now)
+    acquisition_method: AcquisitionMethod = AcquisitionMethod.OTHER
+    amount: Decimal | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _amount_matches_method(self) -> Self:
+        purchased = self.acquisition_method is AcquisitionMethod.PURCHASED
+        if purchased and self.amount is None:
+            raise ValueError("amount is required for a purchased acquisition")
+        if not purchased and self.amount is not None:
+            raise ValueError("amount is only valid for a purchased acquisition")
+        return self
 
 
 class IndividualUpdate(StrictModel):
@@ -25,6 +43,14 @@ class IndividualUpdate(StrictModel):
     father_id: int | None = None
     status: IndividualStatus | None = None
     extra: dict[str, Any] | None = None
+    acquired_at: datetime | None = None
+    acquisition_method: AcquisitionMethod | None = None
+    amount: Decimal | None = Field(default=None, gt=0)
+    died_at: datetime | None = None
+    cause: OptionalStr = Field(default=None, max_length=500)
+    sale_amount: Decimal | None = Field(default=None, gt=0)
+    sold_at: datetime | None = None
+    buyer: OptionalStr = Field(default=None, max_length=255)
 
 
 class IndividualRead(BaseModel):
@@ -40,6 +66,10 @@ class IndividualRead(BaseModel):
     father_id: int | None
     status: IndividualStatus
     extra: dict[str, Any]
+    acquisition_event_id: int | None
+    acquisition_expense_event_id: int | None
+    mortality_event_id: int | None
+    sale_event_id: int | None
     created_at: datetime
     updated_at: datetime
 

--- a/src/ovejitas/features/individual/service.py
+++ b/src/ovejitas/features/individual/service.py
@@ -7,12 +7,25 @@ from ovejitas.core.pagination import PageParams
 from ovejitas.core.search import apply_search
 from ovejitas.core.sorting import apply_sort
 from ovejitas.features.asset.models import Asset, AssetMode
+from ovejitas.features.event.types import AcquisitionMethod
+from ovejitas.features.farm.models import Farm
+from ovejitas.features.individual.acquisition import (
+    emit_acquisition,
+    reconcile_acquisition,
+    reverse_acquisition,
+)
 from ovejitas.features.individual.models import Individual, IndividualStatus
+from ovejitas.features.individual.mortality import apply_mortality, reverse_mortality
+from ovejitas.features.individual.sale import apply_sale, reverse_sale
 from ovejitas.features.individual.schemas import (
     IndividualCreate,
     IndividualFilters,
     IndividualUpdate,
 )
+
+_ACQUISITION_INPUT = {"acquired_at", "acquisition_method", "amount"}
+_MORTALITY_INPUT = {"died_at", "cause"}
+_SALE_INPUT = {"sale_amount", "sold_at", "buyer"}
 
 SEARCH_COLUMNS = [Individual.name, Individual.tag]
 SORT_ALLOWED = {
@@ -29,18 +42,40 @@ class IndividualService:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    async def create(self, asset: Asset, data: IndividualCreate) -> Individual:
+    async def create(self, asset: Asset, user_id: int, data: IndividualCreate) -> Individual:
         if asset.mode is not AssetMode.INDIVIDUAL:
             raise ValidationError("Cannot create an individual under an aggregated asset")
         await self._validate_parents(asset.farm_id, data.mother_id, data.father_id)
+        currency = (
+            await self._farm_currency(asset.farm_id)
+            if data.acquisition_method is AcquisitionMethod.PURCHASED
+            else None
+        )
         individual = Individual(
             farm_id=asset.farm_id,
             asset_id=asset.id,
             status=IndividualStatus.ACTIVE,
-            **data.model_dump(),
+            **data.model_dump(exclude=_ACQUISITION_INPUT),
         )
         self.db.add(individual)
-        await self.db.commit()
+        try:
+            await self.db.flush()
+            acquisition, expense = await emit_acquisition(
+                self.db,
+                individual=individual,
+                asset=asset,
+                method=data.acquisition_method,
+                occurred_at=data.acquired_at,
+                amount=data.amount,
+                currency=currency,
+                user_id=user_id,
+            )
+            individual.acquisition_event_id = acquisition.id
+            individual.acquisition_expense_event_id = expense.id if expense is not None else None
+            await self.db.commit()
+        except Exception:
+            await self.db.rollback()
+            raise
         await self.db.refresh(individual)
         return individual
 
@@ -53,7 +88,9 @@ class IndividualService:
             raise NotFoundError("Individual not found")
         return individual
 
-    async def update(self, asset: Asset, individual_id: int, data: IndividualUpdate) -> Individual:
+    async def update(
+        self, asset: Asset, individual_id: int, user_id: int, data: IndividualUpdate
+    ) -> Individual:
         individual = await self.get(asset.id, individual_id)
         updates = data.model_dump(exclude_unset=True)
         if "mother_id" in updates or "father_id" in updates:
@@ -64,16 +101,64 @@ class IndividualService:
             if mother is not None and mother == father:
                 raise ValidationError("Mother and father cannot be the same individual")
             await self._validate_parents(asset.farm_id, mother, father)
-        for key, value in updates.items():
-            setattr(individual, key, value)
-        await self.db.commit()
+        acquisition_updates = {k: updates.pop(k) for k in _ACQUISITION_INPUT if k in updates}
+        mortality_updates = {k: updates.pop(k) for k in _MORTALITY_INPUT if k in updates}
+        sale_updates = {k: updates.pop(k) for k in _SALE_INPUT if k in updates}
+        new_status = updates.get("status")
+        try:
+            currency = await self._farm_currency(asset.farm_id)
+            if acquisition_updates:
+                await reconcile_acquisition(
+                    self.db,
+                    individual=individual,
+                    asset=asset,
+                    updates=acquisition_updates,
+                    currency=currency,
+                    user_id=user_id,
+                )
+            await apply_mortality(
+                self.db,
+                asset=asset,
+                individual=individual,
+                new_status=new_status,
+                updates=mortality_updates,
+                user_id=user_id,
+            )
+            await apply_sale(
+                self.db,
+                asset=asset,
+                individual=individual,
+                new_status=new_status,
+                updates=sale_updates,
+                currency=currency,
+                user_id=user_id,
+            )
+            for key, value in updates.items():
+                setattr(individual, key, value)
+            await self.db.commit()
+        except Exception:
+            await self.db.rollback()
+            raise
         await self.db.refresh(individual)
         return individual
 
     async def delete(self, asset_id: int, individual_id: int) -> None:
         individual = await self.get(asset_id, individual_id)
-        await self.db.delete(individual)
-        await self.db.commit()
+        try:
+            await reverse_acquisition(self.db, individual=individual)
+            await reverse_mortality(self.db, individual=individual)
+            await reverse_sale(self.db, individual=individual)
+            await self.db.delete(individual)
+            await self.db.commit()
+        except Exception:
+            await self.db.rollback()
+            raise
+
+    async def _farm_currency(self, farm_id: int) -> str:
+        farm = await self.db.get(Farm, farm_id)
+        if farm is None:
+            raise NotFoundError("Farm not found")
+        return farm.default_currency
 
     async def list_individuals(
         self,

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,5 +1,6 @@
 from collections.abc import Awaitable, Callable
 
+import pytest
 from httpx import AsyncClient
 
 from tests.conftest import AuthedUser
@@ -360,3 +361,22 @@ class TestFarmScope:
             headers=bob.headers,
         )
         assert response.status_code == 403
+
+
+class TestActionOwnedTypesRejected:
+    """ACQUISITION and MORTALITY events are owned by individual lifecycle
+    actions and must not be hand-written via POST /events (Philosophy 1)."""
+
+    @pytest.mark.parametrize("event_type", ["acquisition", "mortality"])
+    async def test_action_owned_type_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser, event_type: str
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+
+        response = await client.post(
+            events_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"type": event_type, "occurred_at": OCCURRED, "quantity": "1"},
+        )
+
+        assert response.status_code == 422

--- a/tests/integration/test_individual_acquisition.py
+++ b/tests/integration/test_individual_acquisition.py
@@ -1,0 +1,193 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_INDIVIDUAL = {"name": "Cattle", "kind": "animal", "mode": "individual"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def individuals_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/individuals"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser) -> int:
+    resp = await client.post(
+        assets_url(authed.farm_id), headers=authed.headers, json=ANIMAL_INDIVIDUAL
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, individual_id: int, event_type: str
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"individual_id": individual_id, "type": event_type},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+class TestCreateAcquisition:
+    async def test_create_emits_one_acquisition_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-001"},
+        )
+
+        assert created.status_code == 201, created.text
+        individual_id = created.json()["id"]
+        assert created.json()["acquisition_event_id"] is not None
+        assert created.json()["acquisition_expense_event_id"] is None
+        events = await _events(client, authed_user, asset_id, individual_id, "acquisition")
+        assert len(events) == 1
+        assert events[0]["payload"]["method"] == "other"
+
+    async def test_purchased_create_emits_paired_expense_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-002", "acquisition_method": "purchased", "amount": "1500.00"},
+        )
+
+        assert created.status_code == 201, created.text
+        individual_id = created.json()["id"]
+        assert created.json()["acquisition_expense_event_id"] is not None
+        expenses = await _events(client, authed_user, asset_id, individual_id, "expense")
+        assert len(expenses) == 1
+        assert expenses[0]["amount"] == "1500.00"
+        assert expenses[0]["currency"] == "USD"
+
+    async def test_purchased_without_amount_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+
+        response = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-003", "acquisition_method": "purchased"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_amount_without_purchased_method_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+
+        response = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-004", "acquisition_method": "born", "amount": "200.00"},
+        )
+
+        assert response.status_code == 422
+
+
+class TestUpdateAcquisition:
+    async def test_changing_method_to_purchased_creates_expense(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-005", "acquisition_method": "born"},
+        )
+        individual_id = created.json()["id"]
+
+        updated = await client.patch(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+            json={"acquisition_method": "purchased", "amount": "900.00"},
+        )
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["acquisition_expense_event_id"] is not None
+        expenses = await _events(client, authed_user, asset_id, individual_id, "expense")
+        assert len(expenses) == 1
+        assert expenses[0]["amount"] == "900.00"
+
+    async def test_changing_method_away_from_purchased_deletes_expense(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-006", "acquisition_method": "purchased", "amount": "500.00"},
+        )
+        individual_id = created.json()["id"]
+
+        updated = await client.patch(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+            json={"acquisition_method": "born"},
+        )
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["acquisition_expense_event_id"] is None
+        expenses = await _events(client, authed_user, asset_id, individual_id, "expense")
+        assert expenses == []
+
+    async def test_updating_amount_reconciles_expense(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-007", "acquisition_method": "purchased", "amount": "500.00"},
+        )
+        individual_id = created.json()["id"]
+
+        await client.patch(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+            json={"amount": "750.00"},
+        )
+
+        expenses = await _events(client, authed_user, asset_id, individual_id, "expense")
+        assert len(expenses) == 1
+        assert expenses[0]["amount"] == "750.00"
+
+
+class TestDeleteAcquisition:
+    async def test_delete_removes_acquisition_and_expense_events(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        created = await client.post(
+            individuals_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={"tag": "A-008", "acquisition_method": "purchased", "amount": "300.00"},
+        )
+        individual_id = created.json()["id"]
+
+        delete = await client.delete(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+        )
+
+        assert delete.status_code == 204
+        assert await _events(client, authed_user, asset_id, individual_id, "acquisition") == []
+        assert await _events(client, authed_user, asset_id, individual_id, "expense") == []

--- a/tests/integration/test_individual_mortality.py
+++ b/tests/integration/test_individual_mortality.py
@@ -1,0 +1,168 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_INDIVIDUAL = {"name": "Cattle", "kind": "animal", "mode": "individual"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def individuals_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/individuals"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser) -> int:
+    resp = await client.post(
+        assets_url(authed.farm_id), headers=authed.headers, json=ANIMAL_INDIVIDUAL
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_individual(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, tag: str
+) -> int:
+    resp = await client.post(
+        individuals_url(authed.farm_id, asset_id), headers=authed.headers, json={"tag": tag}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _mortality_events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, individual_id: int
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"individual_id": individual_id, "type": "mortality"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+async def _patch(
+    client: AsyncClient,
+    authed: AuthedUser,
+    asset_id: int,
+    individual_id: int,
+    body: dict[str, object],
+) -> object:
+    return await client.patch(
+        f"{individuals_url(authed.farm_id, asset_id)}/{individual_id}",
+        headers=authed.headers,
+        json=body,
+    )
+
+
+class TestMortalityEmission:
+    async def test_transition_to_deceased_emits_mortality_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-001")
+
+        updated = await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "deceased", "died_at": "2026-05-10T00:00:00Z", "cause": "illness"},
+        )
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["mortality_event_id"] is not None
+        events = await _mortality_events(client, authed_user, asset_id, individual_id)
+        assert len(events) == 1
+        assert events[0]["quantity"] == "1"
+        assert events[0]["notes"] == "illness"
+        assert events[0]["payload"]["source"] == "mortality"
+
+    async def test_repeated_deceased_patch_emits_no_second_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-002")
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "deceased"})
+
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "deceased"})
+
+        events = await _mortality_events(client, authed_user, asset_id, individual_id)
+        assert len(events) == 1
+
+    async def test_died_at_without_deceased_is_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-003")
+
+        response = await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"died_at": "2026-05-10T00:00:00Z"},
+        )
+
+        assert response.status_code == 422
+
+
+class TestMortalityReconcileAndReverse:
+    async def test_editing_died_at_moves_event_without_creating_new(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-004")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "deceased", "died_at": "2026-05-10T00:00:00Z"},
+        )
+
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"died_at": "2026-05-12T00:00:00Z"},
+        )
+
+        events = await _mortality_events(client, authed_user, asset_id, individual_id)
+        assert len(events) == 1
+        assert events[0]["occurred_at"].startswith("2026-05-12")
+
+    async def test_transition_out_of_deceased_reverses_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-005")
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "deceased"})
+
+        updated = await _patch(client, authed_user, asset_id, individual_id, {"status": "active"})
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["mortality_event_id"] is None
+        assert await _mortality_events(client, authed_user, asset_id, individual_id) == []
+
+    async def test_delete_deceased_individual_removes_mortality_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "M-006")
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "deceased"})
+
+        delete = await client.delete(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+        )
+
+        assert delete.status_code == 204
+        assert await _mortality_events(client, authed_user, asset_id, individual_id) == []

--- a/tests/integration/test_individual_sale.py
+++ b/tests/integration/test_individual_sale.py
@@ -1,0 +1,202 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_INDIVIDUAL = {"name": "Cattle", "kind": "animal", "mode": "individual"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def individuals_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/individuals"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser) -> int:
+    resp = await client.post(
+        assets_url(authed.farm_id), headers=authed.headers, json=ANIMAL_INDIVIDUAL
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_individual(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, tag: str
+) -> int:
+    resp = await client.post(
+        individuals_url(authed.farm_id, asset_id), headers=authed.headers, json={"tag": tag}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, individual_id: int, event_type: str
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"individual_id": individual_id, "type": event_type},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+async def _patch(
+    client: AsyncClient,
+    authed: AuthedUser,
+    asset_id: int,
+    individual_id: int,
+    body: dict[str, object],
+) -> object:
+    return await client.patch(
+        f"{individuals_url(authed.farm_id, asset_id)}/{individual_id}",
+        headers=authed.headers,
+        json=body,
+    )
+
+
+class TestSaleEmission:
+    async def test_transition_to_sold_emits_income_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-001")
+
+        updated = await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "1200.00", "buyer": "Rancho Vecino"},
+        )
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["sale_event_id"] is not None
+        events = await _events(client, authed_user, asset_id, individual_id, "income")
+        assert len(events) == 1
+        assert events[0]["amount"] == "1200.00"
+        assert events[0]["currency"] == "USD"
+        assert events[0]["payload"] == {"source": "sale", "buyer": "Rancho Vecino"}
+
+    async def test_transition_to_sold_without_amount_is_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-002")
+
+        response = await _patch(client, authed_user, asset_id, individual_id, {"status": "sold"})
+
+        assert response.status_code == 422
+
+    async def test_repeated_sold_patch_emits_no_second_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-003")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "500.00"},
+        )
+
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "sold"})
+
+        events = await _events(client, authed_user, asset_id, individual_id, "income")
+        assert len(events) == 1
+
+    async def test_sale_fields_without_sold_is_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-004")
+
+        response = await _patch(client, authed_user, asset_id, individual_id, {"buyer": "Someone"})
+
+        assert response.status_code == 422
+
+
+class TestSaleReconcileAndReverse:
+    async def test_editing_sale_amount_moves_event_without_creating_new(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-005")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "500.00"},
+        )
+
+        await _patch(client, authed_user, asset_id, individual_id, {"sale_amount": "650.00"})
+
+        events = await _events(client, authed_user, asset_id, individual_id, "income")
+        assert len(events) == 1
+        assert events[0]["amount"] == "650.00"
+
+    async def test_transition_out_of_sold_reverses_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-006")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "500.00"},
+        )
+
+        updated = await _patch(client, authed_user, asset_id, individual_id, {"status": "active"})
+
+        assert updated.status_code == 200, updated.text
+        assert updated.json()["sale_event_id"] is None
+        assert await _events(client, authed_user, asset_id, individual_id, "income") == []
+
+    async def test_sold_to_deceased_reverses_income_and_emits_mortality(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-007")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "500.00"},
+        )
+
+        await _patch(client, authed_user, asset_id, individual_id, {"status": "deceased"})
+
+        assert await _events(client, authed_user, asset_id, individual_id, "income") == []
+        assert len(await _events(client, authed_user, asset_id, individual_id, "mortality")) == 1
+
+    async def test_delete_sold_individual_removes_income_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user)
+        individual_id = await _create_individual(client, authed_user, asset_id, "S-008")
+        await _patch(
+            client,
+            authed_user,
+            asset_id,
+            individual_id,
+            {"status": "sold", "sale_amount": "500.00"},
+        )
+
+        delete = await client.delete(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{individual_id}",
+            headers=authed_user.headers,
+        )
+
+        assert delete.status_code == 204
+        assert await _events(client, authed_user, asset_id, individual_id, "income") == []

--- a/tests/integration/test_individuals.py
+++ b/tests/integration/test_individuals.py
@@ -104,7 +104,7 @@ class TestListIndividuals:
         await client.patch(
             individual_url(authed_user.farm_id, asset_id, created_c),
             headers=authed_user.headers,
-            json={"status": "sold"},
+            json={"status": "sold", "sale_amount": "100.00"},
         )
 
         response = await client.get(
@@ -153,7 +153,7 @@ class TestGetUpdateDelete:
         response = await client.patch(
             individual_url(authed_user.farm_id, asset_id, individual_id),
             headers=authed_user.headers,
-            json={"status": "sold"},
+            json={"status": "sold", "sale_amount": "100.00"},
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Closes the animal **lifecycle** and **financial** loops: an individual's real-world events (acquisition, death, sale) now feed the derived event ledger instead of being silent status flips (Philosophy 1).
- Hardens `POST /events` so action-owned event types can't be hand-written, keeping the ledger trustworthy.

## Changes

**`feat(individual)` — lifecycle events**
- `IndividualService.create` emits an `acquisition` event; a paired `expense` event when `acquisition_method=purchased`.
- `status → deceased` emits a `mortality` event; `status → sold` emits an `income` event (`sale_amount` required).
- Events are FK-linked from the individual (nullable `acquisition_event_id` / `acquisition_expense_event_id` / `mortality_event_id` / `sale_event_id`), reconcile on edit, and reverse on transition-out or delete — all in one transaction with rollback.
- Per-event helper modules `acquisition.py` / `mortality.py` / `sale.py`; shared detach-before-delete extracted into `event/reversal.py`.
- Three Alembic migrations add the FK columns.

**`feat(event)!` — `POST /events` hardening (breaking)**
- `EventAcquisitionCreate` / `EventMortalityCreate` removed from the `EventCreate` union — `POST /events` returns 422 for `type=acquisition`/`mortality`.
- `inventory` stays creatable (a `reset`/stocktake has no owning action).

## Test plan

- [ ] `docker compose exec app uv run pytest` — 202 passing (new: `test_individual_acquisition.py`, `test_individual_mortality.py`, `test_individual_sale.py`, action-owned-type rejection in `test_events.py`).
- [ ] `docker compose exec app uv run alembic upgrade head` then `downgrade` then `upgrade` — all three migrations apply cleanly both ways.
- [ ] `docker compose exec app uv run mypy src` and `ruff check` — clean.
- [ ] Manual: `POST /events` with `type=acquisition` → 422; create an individual / PATCH status → `deceased`/`sold` and confirm the event appears via the events list endpoint.
