### PR TITLE
feat: birth action and flock lifecycle actions

### DIFF
--- a/docs/api/INDEX.md
+++ b/docs/api/INDEX.md
@@ -12,7 +12,7 @@ Source of truth: [`openapi.json`](../../openapi.json)
 | [events](./events.md) | 6 |
 | [farms](./farms.md) | 2 |
 | [health](./health.md) | 1 |
-| [individuals](./individuals.md) | 5 |
+| [individuals](./individuals.md) | 6 |
 | [material-consumptions](./material-consumptions.md) | 5 |
 | [material-purchases](./material-purchases.md) | 5 |
 | [reports](./reports.md) | 8 |

--- a/docs/api/INDEX.md
+++ b/docs/api/INDEX.md
@@ -11,6 +11,7 @@ Source of truth: [`openapi.json`](../../openapi.json)
 | [event-categories](./event-categories.md) | 5 |
 | [events](./events.md) | 6 |
 | [farms](./farms.md) | 2 |
+| [flock](./flock.md) | 3 |
 | [health](./health.md) | 1 |
 | [individuals](./individuals.md) | 6 |
 | [material-consumptions](./material-consumptions.md) | 5 |

--- a/docs/api/flock.md
+++ b/docs/api/flock.md
@@ -1,0 +1,89 @@
+# flock
+
+_Auto-generated. Do not edit by hand._
+
+## POST /api/v1/farms/{farm_id}/assets/{asset_id}/flock/acquisitions
+
+_Record a flock acquisition_
+
+Increments the flock headcount by `quantity` head via an INVENTORY event; when `amount` is given, also books a paired EXPENSE in the farm's default currency. The asset must be `animal` + `aggregated`.
+
+**Request body:**
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `amount` (number | string | null, optional)
+
+**Responses:**
+- `201` → FlockActionRead — Successful Response
+- `422` → HTTPValidationError — Validation Error
+
+## POST /api/v1/farms/{farm_id}/assets/{asset_id}/flock/sales
+
+_Record a flock sale_
+
+Decrements the flock headcount by `quantity` head and books a paired INCOME event for `amount`. Rejected with 409 if it would drive the headcount below zero.
+
+**Request body:**
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `amount` (number | string, required)
+- `buyer` (string | null, optional)
+
+**Responses:**
+- `201` → FlockActionRead — Successful Response
+- `422` → HTTPValidationError — Validation Error
+
+## POST /api/v1/farms/{farm_id}/assets/{asset_id}/flock/mortalities
+
+_Record a flock mortality_
+
+Decrements the flock headcount by `quantity` head and emits a paired MORTALITY event. Rejected with 409 if it would drive the headcount below zero.
+
+**Request body:**
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `cause` (string | null, optional)
+
+**Responses:**
+- `201` → FlockActionRead — Successful Response
+- `422` → HTTPValidationError — Validation Error
+
+## Types
+
+### FlockAcquisitionCreate
+
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `amount` (number | string | null, optional)
+
+### FlockActionRead
+
+- `inventory_event_id` (integer, required)
+- `paired_event_id` (integer | null, required)
+- `headcount` (string, required)
+
+### FlockMortalityCreate
+
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `cause` (string | null, optional)
+
+### FlockSaleCreate
+
+- `occurred_at` (string (date-time), optional)
+- `quantity` (integer, required)
+- `amount` (number | string, required)
+- `buyer` (string | null, optional)
+
+### HTTPValidationError
+
+- `detail` (ValidationError[], optional)
+
+### ValidationError
+
+- `loc` (string | integer[], required)
+- `msg` (string, required)
+- `type` (string, required)
+- `input` (any, optional)
+- `ctx` (object, optional)
+

--- a/docs/api/individuals.md
+++ b/docs/api/individuals.md
@@ -74,7 +74,40 @@ _Delete an individual_
 - `204` → any — Successful Response
 - `422` → HTTPValidationError — Validation Error
 
+## POST /api/v1/farms/{farm_id}/assets/{asset_id}/individuals/{mother_id}/births
+
+_Record a birth on a mother individual_
+
+Atomically emits a REPRODUCTIVE event on the mother and creates the offspring individuals, each with an ACQUISITION(`born`) event and its `birth_event_id` linked to that reproductive event. The mother must be `active` and under an `animal` asset.
+
+**Request body:**
+- `occurred_at` (string (date-time), optional)
+- `father_id` (integer | null, optional)
+- `category_id` (integer | null, optional)
+- `notes` (string | null, optional)
+- `outcome` (string | null, optional)
+- `offspring` (OffspringCreate[], required)
+
+**Responses:**
+- `201` → BirthRead — Successful Response
+- `422` → HTTPValidationError — Validation Error
+
 ## Types
+
+### BirthCreate
+
+- `occurred_at` (string (date-time), optional)
+- `father_id` (integer | null, optional)
+- `category_id` (integer | null, optional)
+- `notes` (string | null, optional)
+- `outcome` (string | null, optional)
+- `offspring` (OffspringCreate[], required)
+
+### BirthRead
+
+- `reproductive_event_id` (integer, required)
+- `mother_id` (integer, required)
+- `offspring` (IndividualRead[], required)
 
 ### HTTPValidationError
 
@@ -108,6 +141,7 @@ _Delete an individual_
 - `acquisition_expense_event_id` (integer | null, required)
 - `mortality_event_id` (integer | null, required)
 - `sale_event_id` (integer | null, required)
+- `birth_event_id` (integer | null, required)
 - `created_at` (string (date-time), required)
 - `updated_at` (string (date-time), required)
 
@@ -128,6 +162,13 @@ _Delete an individual_
 - `sale_amount` (number | string | null, optional)
 - `sold_at` (string (date-time) | null, optional)
 - `buyer` (string | null, optional)
+
+### OffspringCreate
+
+- `tag` (string, required)
+- `name` (string | null, optional)
+- `birth_date` (string (date) | null, optional)
+- `extra` (object, optional)
 
 ### PageMeta
 

--- a/docs/api/reports.md
+++ b/docs/api/reports.md
@@ -84,9 +84,9 @@ _R3 — PDF download_
 
 ## GET /api/v1/farms/{farm_id}/reports/inventory-summary
 
-_R5 — current on-hand inventory across material assets_
+_R5 — current on-hand inventory per asset_
 
-One row per (material asset, unit). On-hand is derived from INVENTORY events: sum of increments minus decrements since the most recent reset. Date filters bound the events considered, not the resulting balance.
+One row per (asset, unit) for any asset that carries INVENTORY events — material assets and aggregated animal flocks. On-hand is derived from those events: sum of increments minus decrements since the most recent reset. Date filters bound the events considered, not the resulting balance.
 
 **Responses:**
 - `200` → InventorySummaryReport — Successful Response

--- a/migrations/versions/20260518_1000_add_individual_birth_event_fk.py
+++ b/migrations/versions/20260518_1000_add_individual_birth_event_fk.py
@@ -1,0 +1,36 @@
+"""add_individual_birth_event_fk
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-05-18 10:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b8c9d0e1f2a3"
+down_revision: str | None = "a7b8c9d0e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("individual", sa.Column("birth_event_id", sa.Integer(), nullable=True))
+    op.create_index(op.f("ix_individual_birth_event_id"), "individual", ["birth_event_id"])
+    op.create_foreign_key(
+        op.f("fk_individual_birth_event_id_event"),
+        "individual",
+        "event",
+        ["birth_event_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("fk_individual_birth_event_id_event"), "individual", type_="foreignkey")
+    op.drop_index(op.f("ix_individual_birth_event_id"), table_name="individual")
+    op.drop_column("individual", "birth_event_id")

--- a/openapi.json
+++ b/openapi.json
@@ -1583,6 +1583,152 @@
         "title": "FarmUpdate",
         "type": "object"
       },
+      "FlockAcquisitionCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "quantity": {
+            "minimum": 1.0,
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quantity"
+        ],
+        "title": "FlockAcquisitionCreate",
+        "type": "object"
+      },
+      "FlockActionRead": {
+        "description": "The events a flock action emitted, plus the resulting on-hand headcount.\n\n``paired_event_id`` is the expense (acquisition), income (sale), or\nmortality (mortality) event \u2014 null only for an acquisition with no amount.",
+        "properties": {
+          "headcount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Headcount",
+            "type": "string"
+          },
+          "inventory_event_id": {
+            "title": "Inventory Event Id",
+            "type": "integer"
+          },
+          "paired_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paired Event Id"
+          }
+        },
+        "required": [
+          "inventory_event_id",
+          "paired_event_id",
+          "headcount"
+        ],
+        "title": "FlockActionRead",
+        "type": "object"
+      },
+      "FlockMortalityCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "cause": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cause"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "quantity": {
+            "minimum": 1.0,
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quantity"
+        ],
+        "title": "FlockMortalityCreate",
+        "type": "object"
+      },
+      "FlockSaleCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Amount"
+          },
+          "buyer": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buyer"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "quantity": {
+            "minimum": 1.0,
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quantity",
+          "amount"
+        ],
+        "title": "FlockSaleCreate",
+        "type": "object"
+      },
       "GroupBy": {
         "enum": [
           "asset"
@@ -4561,6 +4707,207 @@
         ]
       }
     },
+    "/api/v1/farms/{farm_id}/assets/{asset_id}/flock/acquisitions": {
+      "post": {
+        "description": "Increments the flock headcount by `quantity` head via an INVENTORY event; when `amount` is given, also books a paired EXPENSE in the farm's default currency. The asset must be `animal` + `aggregated`.",
+        "operationId": "flock_create_acquisition",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "farm_id",
+            "required": true,
+            "schema": {
+              "title": "Farm Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlockAcquisitionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlockActionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record a flock acquisition",
+        "tags": [
+          "flock"
+        ]
+      }
+    },
+    "/api/v1/farms/{farm_id}/assets/{asset_id}/flock/mortalities": {
+      "post": {
+        "description": "Decrements the flock headcount by `quantity` head and emits a paired MORTALITY event. Rejected with 409 if it would drive the headcount below zero.",
+        "operationId": "flock_create_mortality",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "farm_id",
+            "required": true,
+            "schema": {
+              "title": "Farm Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlockMortalityCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlockActionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record a flock mortality",
+        "tags": [
+          "flock"
+        ]
+      }
+    },
+    "/api/v1/farms/{farm_id}/assets/{asset_id}/flock/sales": {
+      "post": {
+        "description": "Decrements the flock headcount by `quantity` head and books a paired INCOME event for `amount`. Rejected with 409 if it would drive the headcount below zero.",
+        "operationId": "flock_create_sale",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "farm_id",
+            "required": true,
+            "schema": {
+              "title": "Farm Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlockSaleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlockActionRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record a flock sale",
+        "tags": [
+          "flock"
+        ]
+      }
+    },
     "/api/v1/farms/{farm_id}/assets/{asset_id}/individuals": {
       "get": {
         "operationId": "individuals_list_individuals",
@@ -6772,7 +7119,7 @@
     },
     "/api/v1/farms/{farm_id}/reports/inventory-summary": {
       "get": {
-        "description": "One row per (material asset, unit). On-hand is derived from INVENTORY events: sum of increments minus decrements since the most recent reset. Date filters bound the events considered, not the resulting balance.",
+        "description": "One row per (asset, unit) for any asset that carries INVENTORY events \u2014 material assets and aggregated animal flocks. On-hand is derived from those events: sum of increments minus decrements since the most recent reset. Date filters bound the events considered, not the resulting balance.",
         "operationId": "reports_inventory_summary",
         "parameters": [
           {
@@ -6862,7 +7209,7 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "summary": "R5 \u2014 current on-hand inventory across material assets",
+        "summary": "R5 \u2014 current on-hand inventory per asset",
         "tags": [
           "reports"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -348,6 +348,101 @@
         "title": "AssetUpdate",
         "type": "object"
       },
+      "BirthCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "father_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Father Id"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "offspring": {
+            "items": {
+              "$ref": "#/components/schemas/OffspringCreate"
+            },
+            "minItems": 1,
+            "title": "Offspring",
+            "type": "array"
+          },
+          "outcome": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outcome"
+          }
+        },
+        "required": [
+          "offspring"
+        ],
+        "title": "BirthCreate",
+        "type": "object"
+      },
+      "BirthRead": {
+        "properties": {
+          "mother_id": {
+            "title": "Mother Id",
+            "type": "integer"
+          },
+          "offspring": {
+            "items": {
+              "$ref": "#/components/schemas/IndividualRead"
+            },
+            "title": "Offspring",
+            "type": "array"
+          },
+          "reproductive_event_id": {
+            "title": "Reproductive Event Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "reproductive_event_id",
+          "mother_id",
+          "offspring"
+        ],
+        "title": "BirthRead",
+        "type": "object"
+      },
       "Bucket": {
         "enum": [
           "day",
@@ -1640,6 +1735,17 @@
             ],
             "title": "Birth Date"
           },
+          "birth_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birth Event Id"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -1741,6 +1847,7 @@
           "acquisition_expense_event_id",
           "mortality_event_id",
           "sale_event_id",
+          "birth_event_id",
           "created_at",
           "updated_at"
         ],
@@ -2784,6 +2891,51 @@
           "memberships"
         ],
         "title": "MeResponse",
+        "type": "object"
+      },
+      "OffspringCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "birth_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birth Date"
+          },
+          "extra": {
+            "additionalProperties": true,
+            "title": "Extra",
+            "type": "object"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "tag": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Tag",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ],
+        "title": "OffspringCreate",
         "type": "object"
       },
       "PageMeta": {
@@ -4829,6 +4981,82 @@
           }
         ],
         "summary": "Update an individual",
+        "tags": [
+          "individuals"
+        ]
+      }
+    },
+    "/api/v1/farms/{farm_id}/assets/{asset_id}/individuals/{mother_id}/births": {
+      "post": {
+        "description": "Atomically emits a REPRODUCTIVE event on the mother and creates the offspring individuals, each with an ACQUISITION(`born`) event and its `birth_event_id` linked to that reproductive event. The mother must be `active` and under an `animal` asset.",
+        "operationId": "individuals_create_birth_endpoint",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mother_id",
+            "required": true,
+            "schema": {
+              "title": "Mother Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "farm_id",
+            "required": true,
+            "schema": {
+              "title": "Farm Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BirthCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BirthRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record a birth on a mother individual",
         "tags": [
           "individuals"
         ]

--- a/src/ovejitas/features/event/guards.py
+++ b/src/ovejitas/features/event/guards.py
@@ -8,11 +8,21 @@ from ovejitas.features.event_category.models import EventCategory
 from ovejitas.features.individual.models import Individual
 
 
+def _asset_tracks_inventory(asset: Asset) -> bool:
+    """Inventory events are valid for a material asset, or for a flock — an
+    animal asset counted in aggregate."""
+    if asset.kind is AssetKind.MATERIAL:
+        return True
+    return asset.kind is AssetKind.ANIMAL and asset.mode is AssetMode.AGGREGATED
+
+
 async def validate_type_against_asset(event_type: EventType, asset: Asset) -> None:
     if event_type is EventType.REPRODUCTIVE and asset.kind is not AssetKind.ANIMAL:
         raise ValidationError("Reproductive events require an animal asset")
-    if event_type is EventType.INVENTORY and asset.kind is not AssetKind.MATERIAL:
-        raise ValidationError("Inventory events require a material asset")
+    if event_type is EventType.INVENTORY and not _asset_tracks_inventory(asset):
+        raise ValidationError(
+            "Inventory events require a material asset or an aggregated animal asset"
+        )
 
 
 async def validate_individual(

--- a/src/ovejitas/features/event/inventory.py
+++ b/src/ovejitas/features/event/inventory.py
@@ -19,16 +19,13 @@ from ovejitas.features.asset.models import Asset
 from ovejitas.features.event.models import Event
 from ovejitas.features.event.types import EventType, InventoryAdjustment, Unit
 
-_CONSUMPTION_PAYLOAD = {"source": "material_consumption"}
-_PURCHASE_PAYLOAD = {"source": "material_purchase"}
-
 
 async def _lock_material(db: AsyncSession, asset_id: int) -> None:
     """Serialize concurrent stock mutations on one material asset."""
     await db.execute(select(Asset.id).where(Asset.id == asset_id).with_for_update())
 
 
-async def _on_hand(db: AsyncSession, asset_id: int, unit: Unit) -> Decimal:
+async def on_hand(db: AsyncSession, asset_id: int, unit: Unit) -> Decimal:
     """Replay INVENTORY events to the current on-hand balance for one unit."""
     stmt = (
         select(Event.adjustment, Event.quantity)
@@ -51,7 +48,7 @@ async def _on_hand(db: AsyncSession, asset_id: int, unit: Unit) -> Decimal:
 
 
 async def _assert_non_negative(db: AsyncSession, asset_id: int, unit: Unit) -> None:
-    if await _on_hand(db, asset_id, unit) < 0:
+    if await on_hand(db, asset_id, unit) < 0:
         raise InsufficientStockError(f"Operation would drive '{unit.value}' stock below zero")
 
 
@@ -63,8 +60,12 @@ async def emit_decrement(
     quantity: Decimal,
     occurred_at: datetime,
     created_by: int,
+    source: str,
 ) -> Event:
-    """Create the paired INVENTORY decrement event; reject if it oversells stock."""
+    """Create the paired INVENTORY decrement event; reject if it oversells stock.
+
+    ``source`` tags ``payload.source`` to identify the action that emitted it.
+    """
     await _lock_material(db, material.id)
     event = Event(
         farm_id=material.farm_id,
@@ -74,7 +75,7 @@ async def emit_decrement(
         occurred_at=occurred_at,
         quantity=quantity,
         unit=unit,
-        payload=dict(_CONSUMPTION_PAYLOAD),
+        payload={"source": source},
         created_by=created_by,
     )
     db.add(event)
@@ -118,9 +119,13 @@ async def emit_increment(
     quantity: Decimal,
     occurred_at: datetime,
     created_by: int,
+    source: str,
 ) -> Event:
     """Create the paired INVENTORY increment event. Increments only raise stock,
-    so no guard or lock is needed at create time."""
+    so no guard or lock is needed at create time.
+
+    ``source`` tags ``payload.source`` to identify the action that emitted it.
+    """
     event = Event(
         farm_id=material.farm_id,
         asset_id=material.id,
@@ -129,7 +134,7 @@ async def emit_increment(
         occurred_at=occurred_at,
         quantity=quantity,
         unit=unit,
-        payload=dict(_PURCHASE_PAYLOAD),
+        payload={"source": source},
         created_by=created_by,
     )
     db.add(event)

--- a/src/ovejitas/features/flock/actions.py
+++ b/src/ovejitas/features/flock/actions.py
@@ -1,0 +1,180 @@
+"""The three flock lifecycle actions — acquisition, sale, mortality — for an
+aggregated animal asset. Each is one real-world act recorded as one transaction:
+an ``inventory`` event mutating the headcount, plus a paired finance/mortality
+event. There is no flock table — the event stream is the whole record, with
+``payload.source`` tagging which action emitted each event (Philosophy 1).
+
+Create-only: no reconcile/reverse. Each ``create_*`` owns its commit/rollback.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.inventory import emit_decrement, emit_increment, on_hand
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.types import EventType, Unit
+from ovejitas.features.farm.models import Farm
+from ovejitas.features.flock.guards import validate_flock_asset
+from ovejitas.features.flock.schemas import (
+    FlockAcquisitionCreate,
+    FlockActionRead,
+    FlockMortalityCreate,
+    FlockSaleCreate,
+)
+
+_ACQUISITION_SOURCE = "flock_acquisition"
+_SALE_SOURCE = "flock_sale"
+_MORTALITY_SOURCE = "flock_mortality"
+
+
+async def _farm_currency(db: AsyncSession, farm_id: int) -> str:
+    farm = await db.get(Farm, farm_id)
+    if farm is None:
+        raise NotFoundError("Farm not found")
+    return farm.default_currency
+
+
+def _finance_event(
+    *,
+    asset: Asset,
+    event_type: EventType,
+    amount: Decimal,
+    currency: str,
+    occurred_at: datetime,
+    user_id: int,
+    payload: dict[str, str],
+) -> Event:
+    return Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        type=event_type,
+        occurred_at=occurred_at,
+        amount=amount,
+        currency=currency,
+        payload=payload,
+        created_by=user_id,
+    )
+
+
+async def create_flock_acquisition(
+    db: AsyncSession, *, asset: Asset, user_id: int, data: FlockAcquisitionCreate
+) -> FlockActionRead:
+    """Increment the flock headcount; book a paired expense when an amount is paid."""
+    validate_flock_asset(asset)
+    try:
+        increment = await emit_increment(
+            db,
+            material=asset,
+            unit=Unit.HEAD,
+            quantity=Decimal(data.quantity),
+            occurred_at=data.occurred_at,
+            created_by=user_id,
+            source=_ACQUISITION_SOURCE,
+        )
+        expense_id: int | None = None
+        if data.amount is not None:
+            currency = await _farm_currency(db, asset.farm_id)
+            expense = _finance_event(
+                asset=asset,
+                event_type=EventType.EXPENSE,
+                amount=data.amount,
+                currency=currency,
+                occurred_at=data.occurred_at,
+                user_id=user_id,
+                payload={"source": _ACQUISITION_SOURCE},
+            )
+            db.add(expense)
+            await db.flush()
+            expense_id = expense.id
+        inventory_event_id = increment.id
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    headcount = await on_hand(db, asset.id, Unit.HEAD)
+    return FlockActionRead(
+        inventory_event_id=inventory_event_id, paired_event_id=expense_id, headcount=headcount
+    )
+
+
+async def create_flock_sale(
+    db: AsyncSession, *, asset: Asset, user_id: int, data: FlockSaleCreate
+) -> FlockActionRead:
+    """Decrement the flock headcount and book the paired income."""
+    validate_flock_asset(asset)
+    try:
+        decrement = await emit_decrement(
+            db,
+            material=asset,
+            unit=Unit.HEAD,
+            quantity=Decimal(data.quantity),
+            occurred_at=data.occurred_at,
+            created_by=user_id,
+            source=_SALE_SOURCE,
+        )
+        currency = await _farm_currency(db, asset.farm_id)
+        payload = {"source": _SALE_SOURCE}
+        if data.buyer is not None:
+            payload["buyer"] = data.buyer
+        income = _finance_event(
+            asset=asset,
+            event_type=EventType.INCOME,
+            amount=data.amount,
+            currency=currency,
+            occurred_at=data.occurred_at,
+            user_id=user_id,
+            payload=payload,
+        )
+        db.add(income)
+        await db.flush()
+        inventory_event_id, income_id = decrement.id, income.id
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    headcount = await on_hand(db, asset.id, Unit.HEAD)
+    return FlockActionRead(
+        inventory_event_id=inventory_event_id, paired_event_id=income_id, headcount=headcount
+    )
+
+
+async def create_flock_mortality(
+    db: AsyncSession, *, asset: Asset, user_id: int, data: FlockMortalityCreate
+) -> FlockActionRead:
+    """Decrement the flock headcount and emit a paired mortality event."""
+    validate_flock_asset(asset)
+    try:
+        decrement = await emit_decrement(
+            db,
+            material=asset,
+            unit=Unit.HEAD,
+            quantity=Decimal(data.quantity),
+            occurred_at=data.occurred_at,
+            created_by=user_id,
+            source=_MORTALITY_SOURCE,
+        )
+        mortality = Event(
+            farm_id=asset.farm_id,
+            asset_id=asset.id,
+            type=EventType.MORTALITY,
+            occurred_at=data.occurred_at,
+            quantity=Decimal(data.quantity),
+            notes=data.cause,
+            payload={"source": _MORTALITY_SOURCE},
+            created_by=user_id,
+        )
+        db.add(mortality)
+        await db.flush()
+        inventory_event_id, mortality_id = decrement.id, mortality.id
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    headcount = await on_hand(db, asset.id, Unit.HEAD)
+    return FlockActionRead(
+        inventory_event_id=inventory_event_id, paired_event_id=mortality_id, headcount=headcount
+    )

--- a/src/ovejitas/features/flock/guards.py
+++ b/src/ovejitas/features/flock/guards.py
@@ -1,0 +1,11 @@
+"""Cross-entity validation for flock actions."""
+
+from ovejitas.core.errors import ValidationError
+from ovejitas.features.asset.models import Asset, AssetKind, AssetMode
+
+
+def validate_flock_asset(asset: Asset) -> None:
+    """A flock is an animal asset counted in aggregate — the only asset shape
+    the acquisition/sale/mortality actions operate on."""
+    if asset.kind is not AssetKind.ANIMAL or asset.mode is not AssetMode.AGGREGATED:
+        raise ValidationError("Flock actions require an animal asset in aggregated mode")

--- a/src/ovejitas/features/flock/router.py
+++ b/src/ovejitas/features/flock/router.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, status
+
+from ovejitas.core.deps import DBSession
+from ovejitas.features.asset.deps import AssetDep
+from ovejitas.features.farm_member.deps import FarmMembership
+from ovejitas.features.flock.actions import (
+    create_flock_acquisition,
+    create_flock_mortality,
+    create_flock_sale,
+)
+from ovejitas.features.flock.schemas import (
+    FlockAcquisitionCreate,
+    FlockActionRead,
+    FlockMortalityCreate,
+    FlockSaleCreate,
+)
+
+router = APIRouter(
+    prefix="/farms/{farm_id}/assets/{asset_id}/flock",
+    tags=["flock"],
+)
+
+
+@router.post(
+    "/acquisitions",
+    response_model=FlockActionRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a flock acquisition",
+    description=(
+        "Increments the flock headcount by `quantity` head via an INVENTORY "
+        "event; when `amount` is given, also books a paired EXPENSE in the "
+        "farm's default currency. The asset must be `animal` + `aggregated`."
+    ),
+)
+async def create_acquisition(
+    asset: AssetDep,
+    data: FlockAcquisitionCreate,
+    db: DBSession,
+    membership: FarmMembership,
+) -> FlockActionRead:
+    return await create_flock_acquisition(db, asset=asset, user_id=membership.user_id, data=data)
+
+
+@router.post(
+    "/sales",
+    response_model=FlockActionRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a flock sale",
+    description=(
+        "Decrements the flock headcount by `quantity` head and books a paired "
+        "INCOME event for `amount`. Rejected with 409 if it would drive the "
+        "headcount below zero."
+    ),
+)
+async def create_sale(
+    asset: AssetDep,
+    data: FlockSaleCreate,
+    db: DBSession,
+    membership: FarmMembership,
+) -> FlockActionRead:
+    return await create_flock_sale(db, asset=asset, user_id=membership.user_id, data=data)
+
+
+@router.post(
+    "/mortalities",
+    response_model=FlockActionRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a flock mortality",
+    description=(
+        "Decrements the flock headcount by `quantity` head and emits a paired "
+        "MORTALITY event. Rejected with 409 if it would drive the headcount "
+        "below zero."
+    ),
+)
+async def create_mortality(
+    asset: AssetDep,
+    data: FlockMortalityCreate,
+    db: DBSession,
+    membership: FarmMembership,
+) -> FlockActionRead:
+    return await create_flock_mortality(db, asset=asset, user_id=membership.user_id, data=data)

--- a/src/ovejitas/features/flock/schemas.py
+++ b/src/ovejitas/features/flock/schemas.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from ovejitas.core.schemas import OptionalStr, StrictModel
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class _FlockActionBase(StrictModel):
+    occurred_at: datetime = Field(default_factory=_utc_now)
+    # Headcount is whole animals — integer, never fractional (unlike material kg).
+    quantity: int = Field(ge=1)
+
+
+class FlockAcquisitionCreate(_FlockActionBase):
+    # Optional — a flock can be received free or hatched; when present, the
+    # action books a paired expense for the amount paid.
+    amount: Decimal | None = Field(default=None, gt=0)
+
+
+class FlockSaleCreate(_FlockActionBase):
+    amount: Decimal = Field(gt=0)
+    buyer: OptionalStr = Field(default=None, max_length=255)
+
+
+class FlockMortalityCreate(_FlockActionBase):
+    cause: OptionalStr = Field(default=None, max_length=500)
+
+
+class FlockActionRead(BaseModel):
+    """The events a flock action emitted, plus the resulting on-hand headcount.
+
+    ``paired_event_id`` is the expense (acquisition), income (sale), or
+    mortality (mortality) event — null only for an acquisition with no amount.
+    """
+
+    inventory_event_id: int
+    paired_event_id: int | None
+    headcount: Decimal

--- a/src/ovejitas/features/individual/birth.py
+++ b/src/ovejitas/features/individual/birth.py
@@ -1,0 +1,158 @@
+"""The birth action — one real-world act (an animal giving birth) recorded as
+one transaction: a REPRODUCTIVE event on the mother, N offspring Individual
+rows, and each offspring's ACQUISITION(born) event. Every offspring's
+``birth_event_id`` is linked to the shared reproductive event so the litter is
+a verifiable fact, not a free-floating count (Philosophy 1).
+
+Self-contained: validates, orchestrates, and commits inside one transaction
+with rollback-on-failure. The router calls ``create_birth`` directly. This is
+create-only — there is no birth reconcile/reverse; a mistake is corrected by
+editing the offspring or the event individually.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError, ValidationError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.guards import validate_category, validate_type_against_asset
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.types import AcquisitionMethod, EventType
+from ovejitas.features.individual.acquisition import emit_acquisition
+from ovejitas.features.individual.models import Individual, IndividualStatus
+from ovejitas.features.individual.schemas import BirthCreate, OffspringCreate
+
+_BIRTH_SOURCE = "birth"
+
+
+async def _load_mother(db: AsyncSession, asset: Asset, mother_id: int) -> Individual:
+    stmt = select(Individual).where(Individual.id == mother_id, Individual.asset_id == asset.id)
+    mother = (await db.execute(stmt)).scalar_one_or_none()
+    if mother is None:
+        raise NotFoundError("Mother individual not found")
+    return mother
+
+
+async def _validate_father(
+    db: AsyncSession, farm_id: int, mother_id: int, father_id: int | None
+) -> None:
+    if father_id is None:
+        return
+    if father_id == mother_id:
+        raise ValidationError("Mother and father cannot be the same individual")
+    stmt = select(Individual.id).where(Individual.id == father_id, Individual.farm_id == farm_id)
+    if (await db.execute(stmt)).scalar_one_or_none() is None:
+        raise ValidationError("father not found in this farm")
+
+
+def _reproductive_event(
+    *, mother: Individual, asset: Asset, data: BirthCreate, user_id: int
+) -> Event:
+    payload: dict[str, str] = {"source": _BIRTH_SOURCE}
+    if data.outcome is not None:
+        payload["outcome"] = data.outcome
+    return Event(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        individual_id=mother.id,
+        type=EventType.REPRODUCTIVE,
+        occurred_at=data.occurred_at,
+        category_id=data.category_id,
+        notes=data.notes,
+        payload=payload,
+        created_by=user_id,
+    )
+
+
+def _offspring_individual(
+    *,
+    spec: OffspringCreate,
+    mother: Individual,
+    asset: Asset,
+    father_id: int | None,
+    occurred_at: datetime,
+) -> Individual:
+    return Individual(
+        farm_id=asset.farm_id,
+        asset_id=asset.id,
+        tag=spec.tag,
+        name=spec.name,
+        birth_date=spec.birth_date or occurred_at.date(),
+        mother_id=mother.id,
+        father_id=father_id,
+        status=IndividualStatus.ACTIVE,
+        extra=spec.extra,
+    )
+
+
+async def _create_offspring(
+    db: AsyncSession,
+    *,
+    data: BirthCreate,
+    mother: Individual,
+    asset: Asset,
+    reproductive_id: int,
+    user_id: int,
+) -> list[Individual]:
+    """Insert the offspring rows and emit each one's ACQUISITION(born) event."""
+    offspring = [
+        _offspring_individual(
+            spec=spec,
+            mother=mother,
+            asset=asset,
+            father_id=data.father_id,
+            occurred_at=data.occurred_at,
+        )
+        for spec in data.offspring
+    ]
+    db.add_all(offspring)
+    await db.flush()
+    for child in offspring:
+        acquisition, _ = await emit_acquisition(
+            db,
+            individual=child,
+            asset=asset,
+            method=AcquisitionMethod.BORN,
+            occurred_at=data.occurred_at,
+            amount=None,
+            currency=None,
+            user_id=user_id,
+        )
+        child.acquisition_event_id = acquisition.id
+        child.birth_event_id = reproductive_id
+    await db.flush()
+    return offspring
+
+
+async def create_birth(
+    db: AsyncSession, *, asset: Asset, mother_id: int, user_id: int, data: BirthCreate
+) -> tuple[Event, list[Individual]]:
+    """Record a birth: emit the REPRODUCTIVE event and create the offspring."""
+    await validate_type_against_asset(EventType.REPRODUCTIVE, asset)
+    mother = await _load_mother(db, asset, mother_id)
+    if mother.status is not IndividualStatus.ACTIVE:
+        raise ValidationError("Only an active mother can give birth")
+    await _validate_father(db, asset.farm_id, mother.id, data.father_id)
+    await validate_category(db, asset.farm_id, EventType.REPRODUCTIVE, data.category_id)
+    try:
+        reproductive = _reproductive_event(mother=mother, asset=asset, data=data, user_id=user_id)
+        db.add(reproductive)
+        await db.flush()
+        offspring = await _create_offspring(
+            db,
+            data=data,
+            mother=mother,
+            asset=asset,
+            reproductive_id=reproductive.id,
+            user_id=user_id,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    await db.refresh(reproductive)
+    for child in offspring:
+        await db.refresh(child)
+    return reproductive, offspring

--- a/src/ovejitas/features/individual/models.py
+++ b/src/ovejitas/features/individual/models.py
@@ -79,6 +79,14 @@ class Individual(Base, TimestampMixin):
         nullable=True,
         unique=True,
     )
+    # Set by the birth action on each offspring — points at the shared
+    # REPRODUCTIVE event of the birth that produced it. Many offspring reference
+    # one event, so this is indexed but NOT unique.
+    birth_event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event.id", ondelete="RESTRICT"),
+        nullable=True,
+        index=True,
+    )
     extra: Mapped[dict[str, Any]] = mapped_column(
         JSONB,
         nullable=False,

--- a/src/ovejitas/features/individual/router.py
+++ b/src/ovejitas/features/individual/router.py
@@ -6,7 +6,10 @@ from ovejitas.core.deps import DBSession
 from ovejitas.core.pagination import Page, PageParams
 from ovejitas.features.asset.deps import AssetDep
 from ovejitas.features.farm_member.deps import FarmMembership
+from ovejitas.features.individual.birth import create_birth
 from ovejitas.features.individual.schemas import (
+    BirthCreate,
+    BirthRead,
     IndividualCreate,
     IndividualFilters,
     IndividualRead,
@@ -101,6 +104,35 @@ async def update_individual(
 ) -> IndividualRead:
     return IndividualRead.model_validate(
         await svc.update(asset, individual_id, membership.user_id, data)
+    )
+
+
+@router.post(
+    "/{mother_id}/births",
+    response_model=BirthRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a birth on a mother individual",
+    description=(
+        "Atomically emits a REPRODUCTIVE event on the mother and creates the "
+        "offspring individuals, each with an ACQUISITION(`born`) event and its "
+        "`birth_event_id` linked to that reproductive event. The mother must be "
+        "`active` and under an `animal` asset."
+    ),
+)
+async def create_birth_endpoint(
+    asset: AssetDep,
+    mother_id: int,
+    data: BirthCreate,
+    db: DBSession,
+    membership: FarmMembership,
+) -> BirthRead:
+    reproductive, offspring = await create_birth(
+        db, asset=asset, mother_id=mother_id, user_id=membership.user_id, data=data
+    )
+    return BirthRead(
+        reproductive_event_id=reproductive.id,
+        mother_id=mother_id,
+        offspring=[IndividualRead.model_validate(c) for c in offspring],
     )
 
 

--- a/src/ovejitas/features/individual/schemas.py
+++ b/src/ovejitas/features/individual/schemas.py
@@ -70,9 +70,32 @@ class IndividualRead(BaseModel):
     acquisition_expense_event_id: int | None
     mortality_event_id: int | None
     sale_event_id: int | None
+    birth_event_id: int | None
     created_at: datetime
     updated_at: datetime
 
 
 class IndividualFilters(FilterParams):
     status: IndividualStatus | None = None
+
+
+class OffspringCreate(StrictModel):
+    tag: str = Field(min_length=1, max_length=128)
+    name: OptionalStr = Field(default=None, max_length=255)
+    birth_date: date | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class BirthCreate(StrictModel):
+    occurred_at: datetime = Field(default_factory=_utc_now)
+    father_id: int | None = None
+    category_id: int | None = None
+    notes: OptionalStr = Field(default=None, max_length=500)
+    outcome: OptionalStr = Field(default=None, max_length=255)
+    offspring: list[OffspringCreate] = Field(min_length=1)
+
+
+class BirthRead(BaseModel):
+    reproductive_event_id: int
+    mother_id: int
+    offspring: list[IndividualRead]

--- a/src/ovejitas/features/material_consumption/service.py
+++ b/src/ovejitas/features/material_consumption/service.py
@@ -57,6 +57,7 @@ class MaterialConsumptionService:
                 quantity=data.quantity,
                 occurred_at=data.occurred_at,
                 created_by=user_id,
+                source="material_consumption",
             )
             consumption = MaterialConsumption(
                 farm_id=farm_id,

--- a/src/ovejitas/features/material_purchase/events.py
+++ b/src/ovejitas/features/material_purchase/events.py
@@ -37,6 +37,7 @@ async def emit_pair(
         quantity=data.quantity,
         occurred_at=data.occurred_at,
         created_by=user_id,
+        source="material_purchase",
     )
     expense = await emit_expense(
         db,

--- a/src/ovejitas/features/report/router.py
+++ b/src/ovejitas/features/report/router.py
@@ -199,11 +199,12 @@ async def cost_per_unit_pdf(
 @router.get(
     "/inventory-summary",
     response_model=InventorySummaryReport,
-    summary="R5 — current on-hand inventory across material assets",
+    summary="R5 — current on-hand inventory per asset",
     description=(
-        "One row per (material asset, unit). On-hand is derived from INVENTORY "
-        "events: sum of increments minus decrements since the most recent reset. "
-        "Date filters bound the events considered, not the resulting balance."
+        "One row per (asset, unit) for any asset that carries INVENTORY events — "
+        "material assets and aggregated animal flocks. On-hand is derived from "
+        "those events: sum of increments minus decrements since the most recent "
+        "reset. Date filters bound the events considered, not the resulting balance."
     ),
 )
 async def inventory_summary(

--- a/src/ovejitas/main.py
+++ b/src/ovejitas/main.py
@@ -12,6 +12,7 @@ from ovejitas.features.auth.router import router as auth_router
 from ovejitas.features.event.router import router as event_router
 from ovejitas.features.event_category.router import router as event_category_router
 from ovejitas.features.farm.router import router as farm_router
+from ovejitas.features.flock.router import router as flock_router
 from ovejitas.features.individual.router import router as individual_router
 from ovejitas.features.material_consumption.router import router as material_consumption_router
 from ovejitas.features.material_purchase.router import router as material_purchase_router
@@ -61,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(event_router, prefix=API_PREFIX)
     app.include_router(material_consumption_router, prefix=API_PREFIX)
     app.include_router(material_purchase_router, prefix=API_PREFIX)
+    app.include_router(flock_router, prefix=API_PREFIX)
     app.include_router(report_router, prefix=API_PREFIX)
 
     @app.get("/health", tags=["health"], summary="Liveness check")

--- a/tests/integration/test_flock.py
+++ b/tests/integration/test_flock.py
@@ -1,0 +1,196 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_AGGREGATED = {"name": "Gallinas", "kind": "animal", "mode": "aggregated"}
+ANIMAL_INDIVIDUAL = {"name": "Vacas", "kind": "animal", "mode": "individual"}
+MATERIAL_AGGREGATED = {"name": "Maíz", "kind": "material", "mode": "aggregated"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def flock_url(farm_id: int, asset_id: int, action: str) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/flock/{action}"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser, body: dict[str, str]) -> int:
+    resp = await client.post(assets_url(authed.farm_id), headers=authed.headers, json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, event_type: str
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"type": event_type},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+async def _flock(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, action: str, body: dict[str, object]
+) -> object:
+    return await client.post(
+        flock_url(authed.farm_id, asset_id, action), headers=authed.headers, json=body
+    )
+
+
+class TestFlockAcquisition:
+    async def test_acquisition_increments_headcount(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+
+        resp = await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 20})
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["headcount"] == "20"
+        assert body["paired_event_id"] is None
+        increments = await _events(client, authed_user, asset_id, "inventory")
+        assert len(increments) == 1
+        assert increments[0]["unit"] == "head"
+
+    async def test_acquisition_with_amount_books_expense(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+
+        resp = await _flock(
+            client, authed_user, asset_id, "acquisitions", {"quantity": 20, "amount": "300.00"}
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["paired_event_id"] is not None
+        expenses = await _events(client, authed_user, asset_id, "expense")
+        assert len(expenses) == 1
+        assert expenses[0]["amount"] == "300.00"
+
+    async def test_acquisition_without_amount_books_no_expense(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 20})
+
+        assert await _events(client, authed_user, asset_id, "expense") == []
+
+
+class TestFlockSale:
+    async def test_sale_decrements_headcount_and_books_income(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 20})
+
+        resp = await _flock(
+            client, authed_user, asset_id, "sales", {"quantity": 8, "amount": "120.00"}
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["headcount"] == "12"
+        income = await _events(client, authed_user, asset_id, "income")
+        assert len(income) == 1
+        assert income[0]["amount"] == "120.00"
+
+    async def test_sale_without_amount_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 20})
+
+        resp = await _flock(client, authed_user, asset_id, "sales", {"quantity": 5})
+
+        assert resp.status_code == 422
+
+    async def test_overselling_rejected_and_writes_nothing(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 5})
+
+        resp = await _flock(
+            client, authed_user, asset_id, "sales", {"quantity": 10, "amount": "50.00"}
+        )
+
+        assert resp.status_code == 409
+        assert await _events(client, authed_user, asset_id, "income") == []
+        # the acquisition increment survives; the sale decrement was rolled back
+        assert len(await _events(client, authed_user, asset_id, "inventory")) == 1
+
+
+class TestFlockMortality:
+    async def test_mortality_decrements_headcount_and_emits_event(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 20})
+
+        resp = await _flock(
+            client, authed_user, asset_id, "mortalities", {"quantity": 3, "cause": "fox"}
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["headcount"] == "17"
+        deaths = await _events(client, authed_user, asset_id, "mortality")
+        assert len(deaths) == 1
+        assert deaths[0]["quantity"] == "3"
+
+    async def test_over_culling_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+        await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 2})
+
+        resp = await _flock(client, authed_user, asset_id, "mortalities", {"quantity": 5})
+
+        assert resp.status_code == 409
+        assert await _events(client, authed_user, asset_id, "mortality") == []
+
+
+class TestFlockRejections:
+    async def test_individual_mode_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+
+        resp = await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 10})
+
+        assert resp.status_code == 422
+
+    async def test_non_animal_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, MATERIAL_AGGREGATED)
+
+        resp = await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 10})
+
+        assert resp.status_code == 422
+
+    async def test_fractional_quantity_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+
+        resp = await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 2.5})
+
+        assert resp.status_code == 422
+
+    async def test_zero_quantity_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
+
+        resp = await _flock(client, authed_user, asset_id, "acquisitions", {"quantity": 0})
+
+        assert resp.status_code == 422

--- a/tests/integration/test_individual_birth.py
+++ b/tests/integration/test_individual_birth.py
@@ -1,0 +1,188 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_INDIVIDUAL = {"name": "Cattle", "kind": "animal", "mode": "individual"}
+EQUIPMENT_INDIVIDUAL = {"name": "Tractors", "kind": "equipment", "mode": "individual"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def individuals_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/individuals"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser, body: dict[str, str]) -> int:
+    resp = await client.post(assets_url(authed.farm_id), headers=authed.headers, json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_mother(client: AsyncClient, authed: AuthedUser, asset_id: int, tag: str) -> int:
+    resp = await client.post(
+        individuals_url(authed.farm_id, asset_id), headers=authed.headers, json={"tag": tag}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, individual_id: int, event_type: str
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"individual_id": individual_id, "type": event_type},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+def _births_url(farm_id: int, asset_id: int, mother_id: int) -> str:
+    return f"{individuals_url(farm_id, asset_id)}/{mother_id}/births"
+
+
+class TestCreateBirth:
+    async def test_birth_emits_reproductive_event_and_offspring(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-001")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": [{"tag": "C-1"}, {"tag": "C-2"}, {"tag": "C-3"}]},
+        )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert len(body["offspring"]) == 3
+        reproductive = await _events(client, authed_user, asset_id, mother_id, "reproductive")
+        assert len(reproductive) == 1
+        assert reproductive[0]["id"] == body["reproductive_event_id"]
+        assert reproductive[0]["payload"]["source"] == "birth"
+
+    async def test_offspring_link_to_birth_event_and_mother(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-002")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": [{"tag": "C-1"}, {"tag": "C-2"}]},
+        )
+
+        body = resp.json()
+        event_id = body["reproductive_event_id"]
+        for child in body["offspring"]:
+            assert child["birth_event_id"] == event_id
+            assert child["mother_id"] == mother_id
+            assert child["status"] == "active"
+
+    async def test_offspring_get_born_acquisition_events(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-003")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": [{"tag": "C-1"}]},
+        )
+
+        child_id = resp.json()["offspring"][0]["id"]
+        acquisitions = await _events(client, authed_user, asset_id, child_id, "acquisition")
+        assert len(acquisitions) == 1
+        assert acquisitions[0]["payload"]["method"] == "born"
+
+    async def test_father_id_set_on_offspring(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-004")
+        father_id = await _create_mother(client, authed_user, asset_id, "F-004")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"father_id": father_id, "offspring": [{"tag": "C-1"}, {"tag": "C-2"}]},
+        )
+
+        assert resp.status_code == 201, resp.text
+        for child in resp.json()["offspring"]:
+            assert child["father_id"] == father_id
+
+
+class TestBirthRejections:
+    async def test_birth_with_empty_offspring_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-005")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": []},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_birth_on_deceased_mother_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-006")
+        patched = await client.patch(
+            f"{individuals_url(authed_user.farm_id, asset_id)}/{mother_id}",
+            headers=authed_user.headers,
+            json={"status": "deceased"},
+        )
+        assert patched.status_code == 200, patched.text
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": [{"tag": "C-1"}]},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_birth_on_non_animal_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, EQUIPMENT_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-007")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"offspring": [{"tag": "C-1"}]},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_birth_with_invalid_father_writes_nothing(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        mother_id = await _create_mother(client, authed_user, asset_id, "M-008")
+
+        resp = await client.post(
+            _births_url(authed_user.farm_id, asset_id, mother_id),
+            headers=authed_user.headers,
+            json={"father_id": 999999, "offspring": [{"tag": "C-1"}]},
+        )
+
+        assert resp.status_code == 422
+        assert await _events(client, authed_user, asset_id, mother_id, "reproductive") == []

--- a/tests/integration/test_inventory.py
+++ b/tests/integration/test_inventory.py
@@ -4,6 +4,7 @@ from tests.conftest import AuthedUser
 
 MATERIAL_AGGREGATED = {"name": "Maíz", "kind": "material", "mode": "aggregated"}
 ANIMAL_AGGREGATED = {"name": "Gallinas", "kind": "animal", "mode": "aggregated"}
+ANIMAL_INDIVIDUAL = {"name": "Vacas", "kind": "animal", "mode": "individual"}
 
 
 def assets_url(farm_id: int) -> str:
@@ -84,7 +85,7 @@ class TestCreateInventory:
         )
         assert resp.status_code == 422
 
-    async def test_non_material_asset_rejected(
+    async def test_aggregated_animal_asset_accepted(
         self, client: AsyncClient, authed_user: AuthedUser
     ) -> None:
         asset_id = await _create_asset(client, authed_user, ANIMAL_AGGREGATED)
@@ -96,11 +97,27 @@ class TestCreateInventory:
                 "occurred_at": "2026-04-20T10:00:00Z",
                 "adjustment": "increment",
                 "quantity": "10",
-                "unit": "kg",
+                "unit": "head",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    async def test_individual_mode_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        asset_id = await _create_asset(client, authed_user, ANIMAL_INDIVIDUAL)
+        resp = await client.post(
+            events_url(authed_user.farm_id, asset_id),
+            headers=authed_user.headers,
+            json={
+                "type": "inventory",
+                "occurred_at": "2026-04-20T10:00:00Z",
+                "adjustment": "increment",
+                "quantity": "10",
+                "unit": "head",
             },
         )
         assert resp.status_code == 422
-        assert "material" in resp.json()["detail"].lower()
 
 
 class TestBalance:


### PR DESCRIPTION
## Summary

- Closes the **birth** loop: a litter is now one atomic action instead of N+1 disconnected manual steps, and offspring are FK-linked to the birth event.
- Closes the **flock lifecycle** gap: aggregated animal assets gain a headcount and acquisition/sale/mortality actions — previously they had no count and no economics.
- Both follow Philosophy 1 — a domain action atomically emits its bookkeeping events in one transaction.

## Changes

**Birth action (`feat(individual)`)**
- `POST /farms/{farm_id}/assets/{asset_id}/individuals/{mother_id}/births` — emits the `reproductive` event, creates N offspring, emits each offspring's `acquisition(born)` event.
- New nullable `individual.birth_event_id` FK (indexed, non-unique — many offspring share one event) + Alembic migration.

**Flock lifecycle (`feat(flock)`)**
- New `flock/` feature: three create-only `POST .../flock/{acquisitions,sales,mortalities}` endpoints. No table — pure event-emitters tagged by `payload.source`.
- `inventory` events' `kind=material` restriction lifted to also allow `animal+aggregated` assets; headcount = inventory balance in `head`.
- `emit_increment`/`emit_decrement` gain a `source` parameter (was hardcoded); `_on_hand` exposed as public `on_hand`. Material callers updated.

## Test plan

- [ ] `docker compose exec app uv run pytest` — full suite green (223 passing, incl. 8 birth + 15 flock integration tests).
- [ ] `docker compose exec app uv run alembic upgrade head` — birth-event FK migration applies cleanly.
- [ ] Birth: a mother with 3 offspring returns 201; offspring carry `birth_event_id`, `mother_id`, and `born` acquisition events; deceased mother / invalid father → rejected with rollback.
- [ ] Flock: acquisition/sale/mortality move the headcount and emit the paired expense/income/mortality event; over-sell/over-cull → 409 with nothing written; individual-mode or non-animal asset → 422.
