### PR TITLE
feat: harvest action — production into managed stock

### DIFF
--- a/docs/api/INDEX.md
+++ b/docs/api/INDEX.md
@@ -12,6 +12,7 @@ Source of truth: [`openapi.json`](../../openapi.json)
 | [events](./events.md) | 6 |
 | [farms](./farms.md) | 2 |
 | [flock](./flock.md) | 3 |
+| [harvest](./harvest.md) | 1 |
 | [health](./health.md) | 1 |
 | [individuals](./individuals.md) | 6 |
 | [material-consumptions](./material-consumptions.md) | 5 |

--- a/docs/api/assets.md
+++ b/docs/api/assets.md
@@ -43,6 +43,7 @@ _Update an asset_
 - `mode` ('aggregated' | 'individual' | null, optional)
 - `location` (string | null, optional)
 - `description` (string | null, optional)
+- `produce_asset_id` (integer | null, optional)
 
 **Responses:**
 - `200` → AssetRead — Successful Response
@@ -75,6 +76,7 @@ _Delete an asset_
 - `mode` ('aggregated' | 'individual', required)
 - `location` (string | null, required)
 - `description` (string | null, required)
+- `produce_asset_id` (integer | null, required)
 - `created_at` (string (date-time), required)
 - `updated_at` (string (date-time), required)
 
@@ -85,6 +87,7 @@ _Delete an asset_
 - `mode` ('aggregated' | 'individual' | null, optional)
 - `location` (string | null, optional)
 - `description` (string | null, optional)
+- `produce_asset_id` (integer | null, optional)
 
 ### HTTPValidationError
 

--- a/docs/api/harvest.md
+++ b/docs/api/harvest.md
@@ -1,0 +1,53 @@
+# harvest
+
+_Auto-generated. Do not edit by hand._
+
+## POST /api/v1/farms/{farm_id}/assets/{asset_id}/harvests
+
+_Record a harvest_
+
+Collects produce from an `animal` or `crop` asset: emits a PRODUCTION event on the source asset and an INVENTORY increment on the produce asset linked via the source's `produce_asset_id`. `quantity` and `unit` feed both events; `unit` must match the produce asset's existing stock unit. The source asset must have a produce asset linked.
+
+**Request body:**
+- `occurred_at` (string (date-time), optional)
+- `quantity` (number | string, required)
+- `unit` ('g' | 'kg' | 'lb' | 't' | 'ml' | 'l' | 'gal' | 'unit' | 'dozen' | 'head', required)
+- `category_id` (integer | null, optional)
+- `notes` (string | null, optional)
+
+**Responses:**
+- `201` → HarvestRead — Successful Response
+- `422` → HTTPValidationError — Validation Error
+
+## Types
+
+### HTTPValidationError
+
+- `detail` (ValidationError[], optional)
+
+### HarvestCreate
+
+- `occurred_at` (string (date-time), optional)
+- `quantity` (number | string, required)
+- `unit` ('g' | 'kg' | 'lb' | 't' | 'ml' | 'l' | 'gal' | 'unit' | 'dozen' | 'head', required)
+- `category_id` (integer | null, optional)
+- `notes` (string | null, optional)
+
+### HarvestRead
+
+- `production_event_id` (integer, required)
+- `inventory_event_id` (integer, required)
+- `produce_balance` (string, required)
+
+### ValidationError
+
+- `loc` (string | integer[], required)
+- `msg` (string, required)
+- `type` (string, required)
+- `input` (any, optional)
+- `ctx` (object, optional)
+
+### Unit
+
+**Values:** `g` | `kg` | `lb` | `t` | `ml` | `l` | `gal` | `unit` | `dozen` | `head`
+

--- a/migrations/versions/20260518_1100_add_asset_produce_asset_id.py
+++ b/migrations/versions/20260518_1100_add_asset_produce_asset_id.py
@@ -1,0 +1,36 @@
+"""add_asset_produce_asset_id
+
+Revision ID: c9d0e1f2a3b4
+Revises: b8c9d0e1f2a3
+Create Date: 2026-05-18 11:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9d0e1f2a3b4"
+down_revision: str | None = "b8c9d0e1f2a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("asset", sa.Column("produce_asset_id", sa.Integer(), nullable=True))
+    op.create_index(op.f("ix_asset_produce_asset_id"), "asset", ["produce_asset_id"])
+    op.create_foreign_key(
+        op.f("fk_asset_produce_asset_id_asset"),
+        "asset",
+        "asset",
+        ["produce_asset_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("fk_asset_produce_asset_id_asset"), "asset", type_="foreignkey")
+    op.drop_index(op.f("ix_asset_produce_asset_id"), table_name="asset")
+    op.drop_column("asset", "produce_asset_id")

--- a/openapi.json
+++ b/openapi.json
@@ -264,6 +264,17 @@
             "title": "Name",
             "type": "string"
           },
+          "produce_asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Produce Asset Id"
+          },
           "updated_at": {
             "format": "date-time",
             "title": "Updated At",
@@ -278,6 +289,7 @@
           "mode",
           "location",
           "description",
+          "produce_asset_id",
           "created_at",
           "updated_at"
         ],
@@ -343,6 +355,17 @@
               }
             ],
             "title": "Name"
+          },
+          "produce_asset_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Produce Asset Id"
           }
         },
         "title": "AssetUpdate",
@@ -1747,6 +1770,86 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HarvestCreate": {
+        "additionalProperties": false,
+        "properties": {
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "occurred_at": {
+            "format": "date-time",
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Quantity"
+          },
+          "unit": {
+            "$ref": "#/components/schemas/Unit"
+          }
+        },
+        "required": [
+          "quantity",
+          "unit"
+        ],
+        "title": "HarvestCreate",
+        "type": "object"
+      },
+      "HarvestRead": {
+        "description": "The two events a harvest emitted, plus the produce asset's resulting\non-hand balance in the harvested unit.",
+        "properties": {
+          "inventory_event_id": {
+            "title": "Inventory Event Id",
+            "type": "integer"
+          },
+          "produce_balance": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Produce Balance",
+            "type": "string"
+          },
+          "production_event_id": {
+            "title": "Production Event Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "production_event_id",
+          "inventory_event_id",
+          "produce_balance"
+        ],
+        "title": "HarvestRead",
         "type": "object"
       },
       "IndividualCreate": {
@@ -4905,6 +5008,73 @@
         "summary": "Record a flock sale",
         "tags": [
           "flock"
+        ]
+      }
+    },
+    "/api/v1/farms/{farm_id}/assets/{asset_id}/harvests": {
+      "post": {
+        "description": "Collects produce from an `animal` or `crop` asset: emits a PRODUCTION event on the source asset and an INVENTORY increment on the produce asset linked via the source's `produce_asset_id`. `quantity` and `unit` feed both events; `unit` must match the produce asset's existing stock unit. The source asset must have a produce asset linked.",
+        "operationId": "harvest_create_harvest_endpoint",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "farm_id",
+            "required": true,
+            "schema": {
+              "title": "Farm Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset_id",
+            "required": true,
+            "schema": {
+              "title": "Asset Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HarvestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HarvestRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record a harvest",
+        "tags": [
+          "harvest"
         ]
       }
     },

--- a/src/ovejitas/features/asset/models.py
+++ b/src/ovejitas/features/asset/models.py
@@ -41,3 +41,11 @@ class Asset(Base, TimestampMixin):
     )
     location: Mapped[str | None] = mapped_column(String(255), nullable=True)
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    # The produce material asset this asset harvests into (e.g. a hen flock ->
+    # an "Eggs" asset). Set on animal/crop assets; null until linked. SET NULL
+    # on delete so a deleted produce asset just unlinks rather than dangling.
+    produce_asset_id: Mapped[int | None] = mapped_column(
+        ForeignKey("asset.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )

--- a/src/ovejitas/features/asset/schemas.py
+++ b/src/ovejitas/features/asset/schemas.py
@@ -21,6 +21,7 @@ class AssetUpdate(StrictModel):
     mode: AssetMode | None = None
     location: OptionalStr = Field(default=None, max_length=255)
     description: OptionalStr = Field(default=None, max_length=1024)
+    produce_asset_id: int | None = None
 
 
 class AssetRead(BaseModel):
@@ -33,6 +34,7 @@ class AssetRead(BaseModel):
     mode: AssetMode
     location: str | None
     description: str | None
+    produce_asset_id: int | None
     created_at: datetime
     updated_at: datetime
 

--- a/src/ovejitas/features/asset/service.py
+++ b/src/ovejitas/features/asset/service.py
@@ -1,12 +1,12 @@
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ovejitas.core.errors import NotFoundError
+from ovejitas.core.errors import NotFoundError, ValidationError
 from ovejitas.core.filters import apply_date_range
 from ovejitas.core.pagination import PageParams
 from ovejitas.core.search import apply_search
 from ovejitas.core.sorting import apply_sort
-from ovejitas.features.asset.models import Asset
+from ovejitas.features.asset.models import Asset, AssetKind
 from ovejitas.features.asset.schemas import AssetCreate, AssetFilters, AssetUpdate
 
 SEARCH_COLUMNS = [Asset.name, Asset.description, Asset.location]
@@ -38,11 +38,26 @@ class AssetService:
 
     async def update(self, farm_id: int, asset_id: int, data: AssetUpdate) -> Asset:
         asset = await self.get(farm_id, asset_id)
-        for key, value in data.model_dump(exclude_unset=True).items():
+        updates = data.model_dump(exclude_unset=True)
+        if updates.get("produce_asset_id") is not None:
+            source_kind = updates.get("kind", asset.kind)
+            await self._validate_produce_link(farm_id, source_kind, updates["produce_asset_id"])
+        for key, value in updates.items():
             setattr(asset, key, value)
         await self.db.commit()
         await self.db.refresh(asset)
         return asset
+
+    async def _validate_produce_link(
+        self, farm_id: int, source_kind: AssetKind, produce_asset_id: int
+    ) -> None:
+        """A produce link is only meaningful on an asset that produces, and must
+        point at a material asset in the same farm."""
+        if source_kind not in (AssetKind.ANIMAL, AssetKind.CROP):
+            raise ValidationError("Only animal or crop assets can link a produce asset")
+        target = await self.get(farm_id, produce_asset_id)
+        if target.kind is not AssetKind.MATERIAL:
+            raise ValidationError("produce_asset_id must reference a material asset")
 
     async def delete(self, farm_id: int, asset_id: int) -> None:
         asset = await self.get(farm_id, asset_id)

--- a/src/ovejitas/features/harvest/actions.py
+++ b/src/ovejitas/features/harvest/actions.py
@@ -1,0 +1,68 @@
+"""The harvest action — collecting produce (eggs, milk, a crop yield) from an
+animal or crop asset. One real-world act recorded as one transaction: a
+PRODUCTION event on the source asset (per-source productivity) plus an
+INVENTORY increment on the linked produce material asset (managed stock),
+turning production into sellable inventory (Philosophy 1).
+
+Create-only: no reconcile/reverse. The router calls ``create_harvest`` directly.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import NotFoundError
+from ovejitas.features.asset.models import Asset
+from ovejitas.features.event.guards import validate_category
+from ovejitas.features.event.inventory import emit_increment, on_hand
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.types import EventType
+from ovejitas.features.harvest.guards import validate_harvest_source, validate_produce_unit
+from ovejitas.features.harvest.schemas import HarvestCreate, HarvestRead
+
+_HARVEST_SOURCE = "harvest"
+
+
+async def create_harvest(
+    db: AsyncSession, *, asset: Asset, user_id: int, data: HarvestCreate
+) -> HarvestRead:
+    """Emit the PRODUCTION event on ``asset`` and increment its linked produce
+    asset's stock by the same quantity, atomically."""
+    validate_harvest_source(asset)
+    produce_asset = await db.get(Asset, asset.produce_asset_id)
+    if produce_asset is None:
+        raise NotFoundError("Linked produce asset not found")
+    await validate_produce_unit(db, produce_asset.id, data.unit)
+    await validate_category(db, asset.farm_id, EventType.PRODUCTION, data.category_id)
+    try:
+        production = Event(
+            farm_id=asset.farm_id,
+            asset_id=asset.id,
+            type=EventType.PRODUCTION,
+            occurred_at=data.occurred_at,
+            quantity=data.quantity,
+            unit=data.unit,
+            category_id=data.category_id,
+            notes=data.notes,
+            payload={"source": _HARVEST_SOURCE},
+            created_by=user_id,
+        )
+        db.add(production)
+        increment = await emit_increment(
+            db,
+            material=produce_asset,
+            unit=data.unit,
+            quantity=data.quantity,
+            occurred_at=data.occurred_at,
+            created_by=user_id,
+            source=_HARVEST_SOURCE,
+        )
+        production_event_id, inventory_event_id = production.id, increment.id
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    produce_balance = await on_hand(db, produce_asset.id, data.unit)
+    return HarvestRead(
+        production_event_id=production_event_id,
+        inventory_event_id=inventory_event_id,
+        produce_balance=produce_balance,
+    )

--- a/src/ovejitas/features/harvest/guards.py
+++ b/src/ovejitas/features/harvest/guards.py
@@ -1,0 +1,36 @@
+"""Cross-entity validation for the harvest action."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ovejitas.core.errors import ValidationError
+from ovejitas.features.asset.models import Asset, AssetKind
+from ovejitas.features.event.models import Event
+from ovejitas.features.event.types import EventType, Unit
+
+
+def validate_harvest_source(asset: Asset) -> None:
+    """The source must be something that produces and must have a produce
+    asset linked to receive the harvest."""
+    if asset.kind not in (AssetKind.ANIMAL, AssetKind.CROP):
+        raise ValidationError("Harvest requires an animal or crop asset")
+    if asset.produce_asset_id is None:
+        raise ValidationError("This asset has no produce asset linked")
+
+
+async def validate_produce_unit(db: AsyncSession, produce_asset_id: int, unit: Unit) -> None:
+    """A produce asset holds stock in a single unit. The first harvest into an
+    empty produce asset sets that unit; later harvests must match it."""
+    stmt = (
+        select(Event.unit)
+        .where(
+            Event.asset_id == produce_asset_id,
+            Event.type == EventType.INVENTORY,
+        )
+        .limit(1)
+    )
+    existing = (await db.execute(stmt)).scalar_one_or_none()
+    if existing is not None and existing != unit:
+        raise ValidationError(
+            f"Produce asset already tracks stock in '{existing.value}' — harvest unit must match"
+        )

--- a/src/ovejitas/features/harvest/router.py
+++ b/src/ovejitas/features/harvest/router.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, status
+
+from ovejitas.core.deps import DBSession
+from ovejitas.features.asset.deps import AssetDep
+from ovejitas.features.farm_member.deps import FarmMembership
+from ovejitas.features.harvest.actions import create_harvest
+from ovejitas.features.harvest.schemas import HarvestCreate, HarvestRead
+
+router = APIRouter(
+    prefix="/farms/{farm_id}/assets/{asset_id}/harvests",
+    tags=["harvest"],
+)
+
+
+@router.post(
+    "",
+    response_model=HarvestRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a harvest",
+    description=(
+        "Collects produce from an `animal` or `crop` asset: emits a PRODUCTION "
+        "event on the source asset and an INVENTORY increment on the produce "
+        "asset linked via the source's `produce_asset_id`. `quantity` and "
+        "`unit` feed both events; `unit` must match the produce asset's "
+        "existing stock unit. The source asset must have a produce asset linked."
+    ),
+)
+async def create_harvest_endpoint(
+    asset: AssetDep,
+    data: HarvestCreate,
+    db: DBSession,
+    membership: FarmMembership,
+) -> HarvestRead:
+    return await create_harvest(db, asset=asset, user_id=membership.user_id, data=data)

--- a/src/ovejitas/features/harvest/schemas.py
+++ b/src/ovejitas/features/harvest/schemas.py
@@ -1,0 +1,28 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from ovejitas.core.schemas import OptionalStr, StrictModel
+from ovejitas.features.event.types import Unit
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class HarvestCreate(StrictModel):
+    occurred_at: datetime = Field(default_factory=_utc_now)
+    quantity: Decimal = Field(gt=0)
+    unit: Unit
+    category_id: int | None = None
+    notes: OptionalStr = Field(default=None, max_length=500)
+
+
+class HarvestRead(BaseModel):
+    """The two events a harvest emitted, plus the produce asset's resulting
+    on-hand balance in the harvested unit."""
+
+    production_event_id: int
+    inventory_event_id: int
+    produce_balance: Decimal

--- a/src/ovejitas/main.py
+++ b/src/ovejitas/main.py
@@ -13,6 +13,7 @@ from ovejitas.features.event.router import router as event_router
 from ovejitas.features.event_category.router import router as event_category_router
 from ovejitas.features.farm.router import router as farm_router
 from ovejitas.features.flock.router import router as flock_router
+from ovejitas.features.harvest.router import router as harvest_router
 from ovejitas.features.individual.router import router as individual_router
 from ovejitas.features.material_consumption.router import router as material_consumption_router
 from ovejitas.features.material_purchase.router import router as material_purchase_router
@@ -63,6 +64,7 @@ def create_app() -> FastAPI:
     app.include_router(material_consumption_router, prefix=API_PREFIX)
     app.include_router(material_purchase_router, prefix=API_PREFIX)
     app.include_router(flock_router, prefix=API_PREFIX)
+    app.include_router(harvest_router, prefix=API_PREFIX)
     app.include_router(report_router, prefix=API_PREFIX)
 
     @app.get("/health", tags=["health"], summary="Liveness check")

--- a/tests/integration/test_harvest.py
+++ b/tests/integration/test_harvest.py
@@ -1,0 +1,203 @@
+from httpx import AsyncClient
+
+from tests.conftest import AuthedUser
+
+ANIMAL_FLOCK = {"name": "Gallinas", "kind": "animal", "mode": "aggregated"}
+CROP_FIELD = {"name": "Tomateras", "kind": "crop", "mode": "aggregated"}
+EQUIPMENT = {"name": "Tractor", "kind": "equipment", "mode": "individual"}
+EGGS = {"name": "Huevos", "kind": "material", "mode": "aggregated"}
+
+
+def assets_url(farm_id: int) -> str:
+    return f"/api/v1/farms/{farm_id}/assets"
+
+
+def harvest_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/harvests"
+
+
+def events_url(farm_id: int, asset_id: int) -> str:
+    return f"{assets_url(farm_id)}/{asset_id}/events"
+
+
+async def _create_asset(client: AsyncClient, authed: AuthedUser, body: dict[str, str]) -> int:
+    resp = await client.post(assets_url(authed.farm_id), headers=authed.headers, json=body)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _link_produce(
+    client: AsyncClient, authed: AuthedUser, source_id: int, produce_id: int
+) -> object:
+    return await client.patch(
+        f"{assets_url(authed.farm_id)}/{source_id}",
+        headers=authed.headers,
+        json={"produce_asset_id": produce_id},
+    )
+
+
+async def _events(
+    client: AsyncClient, authed: AuthedUser, asset_id: int, event_type: str
+) -> list[dict[str, object]]:
+    resp = await client.get(
+        events_url(authed.farm_id, asset_id),
+        headers=authed.headers,
+        params={"type": event_type},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+async def _linked_source(
+    client: AsyncClient, authed: AuthedUser, source_body: dict[str, str]
+) -> tuple[int, int]:
+    """Create a source asset linked to a fresh 'Huevos' produce asset."""
+    produce_id = await _create_asset(client, authed, EGGS)
+    source_id = await _create_asset(client, authed, source_body)
+    linked = await _link_produce(client, authed, source_id, produce_id)
+    assert linked.status_code == 200, linked.text
+    return source_id, produce_id
+
+
+class TestHarvest:
+    async def test_harvest_emits_production_and_increments_stock(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id, produce_id = await _linked_source(client, authed_user, ANIMAL_FLOCK)
+
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "15", "unit": "unit"},
+        )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["produce_balance"] == "15"
+        production = await _events(client, authed_user, source_id, "production")
+        assert len(production) == 1
+        assert production[0]["id"] == body["production_event_id"]
+        increments = await _events(client, authed_user, produce_id, "inventory")
+        assert len(increments) == 1
+        assert increments[0]["id"] == body["inventory_event_id"]
+
+    async def test_events_carry_correct_asset_ids(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id, produce_id = await _linked_source(client, authed_user, ANIMAL_FLOCK)
+
+        await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "15", "unit": "unit"},
+        )
+
+        production = await _events(client, authed_user, source_id, "production")
+        increments = await _events(client, authed_user, produce_id, "inventory")
+        assert production[0]["asset_id"] == source_id
+        assert increments[0]["asset_id"] == produce_id
+
+    async def test_two_flocks_pool_into_one_produce_balance(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        produce_id = await _create_asset(client, authed_user, EGGS)
+        flock_a = await _create_asset(client, authed_user, ANIMAL_FLOCK)
+        flock_b = await _create_asset(client, authed_user, ANIMAL_FLOCK)
+        await _link_produce(client, authed_user, flock_a, produce_id)
+        await _link_produce(client, authed_user, flock_b, produce_id)
+
+        await client.post(
+            harvest_url(authed_user.farm_id, flock_a),
+            headers=authed_user.headers,
+            json={"quantity": "10", "unit": "unit"},
+        )
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, flock_b),
+            headers=authed_user.headers,
+            json={"quantity": "7", "unit": "unit"},
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["produce_balance"] == "17"
+
+    async def test_harvest_from_crop_asset(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id, _ = await _linked_source(client, authed_user, CROP_FIELD)
+
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "40", "unit": "kg"},
+        )
+
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["produce_balance"] == "40"
+
+
+class TestHarvestRejections:
+    async def test_harvest_from_unlinked_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id = await _create_asset(client, authed_user, ANIMAL_FLOCK)
+
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "15", "unit": "unit"},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_unit_must_match_produce_stock(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id, _ = await _linked_source(client, authed_user, ANIMAL_FLOCK)
+        await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "15", "unit": "unit"},
+        )
+
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "1", "unit": "dozen"},
+        )
+
+        assert resp.status_code == 422
+
+    async def test_zero_quantity_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        source_id, _ = await _linked_source(client, authed_user, ANIMAL_FLOCK)
+
+        resp = await client.post(
+            harvest_url(authed_user.farm_id, source_id),
+            headers=authed_user.headers,
+            json={"quantity": "0", "unit": "unit"},
+        )
+
+        assert resp.status_code == 422
+
+
+class TestProduceLinkValidation:
+    async def test_link_to_non_material_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        flock = await _create_asset(client, authed_user, ANIMAL_FLOCK)
+        other_flock = await _create_asset(client, authed_user, ANIMAL_FLOCK)
+
+        resp = await _link_produce(client, authed_user, flock, other_flock)
+
+        assert resp.status_code == 422
+
+    async def test_link_on_equipment_asset_rejected(
+        self, client: AsyncClient, authed_user: AuthedUser
+    ) -> None:
+        equipment = await _create_asset(client, authed_user, EQUIPMENT)
+        produce = await _create_asset(client, authed_user, EGGS)
+
+        resp = await _link_produce(client, authed_user, equipment, produce)
+
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Closes the first link of the production loop: a `production` event was a dead number — it recorded a measurement but increased no stock. Harvest turns produce into managed, countable inventory.
- Follows Philosophy 1 — collecting produce is one real-world act recorded as one transaction that atomically emits its bookkeeping events.

## Changes

- New `harvest/` feature: create-only `POST /farms/{farm_id}/assets/{asset_id}/harvests`. In one transaction it emits a `production` event on the source `animal`/`crop` asset and an `inventory` increment on the linked produce `material` asset.
- New nullable self-referential FK `asset.produce_asset_id` (`ON DELETE SET NULL`, indexed) — links a source asset to the produce asset its harvests flow into. Set via the existing `PATCH .../assets/{id}`, validated (target is a same-farm `material` asset; source is `animal`/`crop`).
- Stock is **pooled** — multiple source assets may link to one produce asset; per-source productivity is preserved on the `production` events.
- `quantity` + `unit` feed both events; `unit` must match the produce asset's existing stock unit (first harvest sets it).

## Test plan

- [ ] `docker compose exec app uv run pytest` — full suite green (232 passing, incl. 11 harvest integration tests).
- [ ] `docker compose exec app uv run alembic upgrade head` — the `produce_asset_id` migration applies cleanly.
- [ ] `PATCH .../assets/{id}` with `produce_asset_id` → link stored; pointing at a non-material or cross-farm asset, or setting it on an equipment asset → `422`.
- [ ] Harvest → `201`; `production` event lands on the source asset, `inventory` increment on the produce asset, response shows the new pooled balance.
- [ ] Two flocks linked to one produce asset raise the same pooled balance.
- [ ] Harvest from an unlinked asset, with a mismatched unit, or `quantity ≤ 0` → `422`.
